### PR TITLE
Separate ReactTable-specific logic from Jobs/Groups logic

### DIFF
--- a/src/components/JobsTable.tsx
+++ b/src/components/JobsTable.tsx
@@ -28,7 +28,7 @@ import GetJobsService from "services/GetJobsService"
 import { GroupAddOutlined, GroupRemoveOutlined, ExpandMore, KeyboardArrowRight } from "@mui/icons-material"
 import GroupJobsService from "services/GroupJobsService"
 import { usePrevious } from "hooks/usePrevious"
-import { JobTableRow, JobRow, fetchAllNeededRows, isJobGroupRow, FetchAllNeededRowsRequest } from "utils/jobsTableUtils"
+import { JobTableRow, JobRow, fetchAndMergeNewRows, isJobGroupRow } from "utils/jobsTableUtils"
 import { ColumnSpec } from "pages/JobsPage"
 
 type JobsPageProps = {
@@ -94,16 +94,14 @@ export const JobsTable = ({ getJobsService, groupJobsService, selectedColumns }:
 
       const parentRowId = newlyExpanded.length > 0 ? newlyExpanded[0] : undefined
 
-      const rowRequests: FetchAllNeededRowsRequest = [
-        {
-          parentRowId: parentRowId,
-          skip: parentRowId ? 0 : pageIndex * pageSize,
-          take: parentRowId ? Number.MAX_SAFE_INTEGER : pageSize,
-        },
-      ]
+      const rowRequest = {
+        parentRowId: parentRowId,
+        skip: parentRowId ? 0 : pageIndex * pageSize,
+        take: parentRowId ? Number.MAX_SAFE_INTEGER : pageSize,
+      };
 
-      const { rows, updatedRootCount } = await fetchAllNeededRows(
-        rowRequests,
+      const { rows, updatedRootCount } = await fetchAndMergeNewRows(
+        rowRequest,
         data ?? [],
         getJobsService,
         groupJobsService,
@@ -113,7 +111,7 @@ export const JobsTable = ({ getJobsService, groupJobsService, selectedColumns }:
 
       setData(rows)
       setIsLoading(false)
-      if (updatedRootCount) {
+      if (updatedRootCount !== undefined) {
         setPageCount(Math.ceil(updatedRootCount / pageSize))
       }
     }

--- a/src/components/JobsTable.tsx
+++ b/src/components/JobsTable.tsx
@@ -98,7 +98,7 @@ export const JobsTable = ({ getJobsService, groupJobsService, selectedColumns }:
         parentRowId: parentRowId,
         skip: parentRowId ? 0 : pageIndex * pageSize,
         take: parentRowId ? Number.MAX_SAFE_INTEGER : pageSize,
-      };
+      }
 
       const { rows, updatedRootCount } = await fetchAndMergeNewRows(
         rowRequest,

--- a/src/components/JobsTable.tsx
+++ b/src/components/JobsTable.tsx
@@ -30,6 +30,7 @@ import GroupJobsService from "services/GroupJobsService"
 import { usePrevious } from "hooks/usePrevious"
 import { JobTableRow, JobRow, fetchAndMergeNewRows, isJobGroupRow } from "utils/jobsTableUtils"
 import { ColumnSpec } from "pages/JobsPage"
+import { RowId } from "utils/reactTableUtils"
 
 type JobsPageProps = {
   getJobsService: GetJobsService
@@ -58,11 +59,11 @@ export const JobsTable = ({ getJobsService, groupJobsService, selectedColumns }:
   const [expanded, setExpanded] = React.useState<ExpandedState>({})
   const prevExpanded = usePrevious(expanded)
   const { newlyExpanded, newlyUnexpanded } = React.useMemo(() => {
-    const prevExpandedKeys = Object.keys(prevExpanded ?? {})
-    const expandedKeys = Object.keys(expanded)
+    const prevExpandedKeys = Object.keys(prevExpanded ?? {}) as RowId[]
+    const expandedKeys = Object.keys(expanded) as RowId[]
 
-    const newlyExpanded = expandedKeys.filter((e) => !prevExpandedKeys.includes(e))
-    const newlyUnexpanded = prevExpandedKeys.filter((e) => !expandedKeys.includes(e))
+    const newlyExpanded: RowId[] = expandedKeys.filter((e) => !prevExpandedKeys.includes(e))
+    const newlyUnexpanded: RowId[] = prevExpandedKeys.filter((e) => !expandedKeys.includes(e))
     return { newlyExpanded, newlyUnexpanded }
   }, [expanded, prevExpanded])
 
@@ -99,6 +100,8 @@ export const JobsTable = ({ getJobsService, groupJobsService, selectedColumns }:
         skip: parentRowId ? 0 : pageIndex * pageSize,
         take: parentRowId ? Number.MAX_SAFE_INTEGER : pageSize,
       }
+
+      console.log({ parentRowId })
 
       const { rows, updatedRootCount } = await fetchAndMergeNewRows(
         rowRequest,

--- a/src/models/jobsTableModels.ts
+++ b/src/models/jobsTableModels.ts
@@ -1,0 +1,29 @@
+import { RowId } from "utils/reactTableUtils"
+
+export interface BaseJobTableRow {
+    rowId: RowId
+}
+
+export interface JobRow extends BaseJobTableRow {
+    // Job details
+    jobId?: string
+    jobSet?: string
+    queue?: string
+    state?: string
+    cpu?: number
+    memory?: string
+    ephemeralStorage?: string
+}
+
+export interface JobGroupRow extends BaseJobTableRow {
+    isGroup: true // The ReactTable version of this doesn't seem to play nice with manual/serverside expanding
+    count?: number
+    subRows?: JobTableRow[]
+
+    // Some subfield of JobRow that this row is grouped on
+    [groupedField: string]: unknown
+}
+
+export type JobTableRow = JobRow | JobGroupRow
+
+export const isJobGroupRow = (row: JobTableRow): row is JobGroupRow => "isGroup" in row

--- a/src/utils/jobsTableUtils.test.ts
+++ b/src/utils/jobsTableUtils.test.ts
@@ -1,0 +1,185 @@
+import { Job } from "model"
+import { ColumnSpec } from "pages/JobsPage"
+import GetJobsService from "services/GetJobsService"
+import GroupJobsService from "services/GroupJobsService"
+import FakeGetJobsService from "services/mocks/FakeGetJobsService"
+import FakeGroupJobsService from "services/mocks/FakeGroupJobsService"
+import { makeTestJobs } from "utils"
+import { fetchAndMergeNewRows, JobTableRow } from "./jobsTableUtils"
+
+describe("JobsTableUtils", () => {
+  let jobs: Job[], getJobsService: GetJobsService, groupJobsService: GroupJobsService
+
+  beforeEach(() => {
+    jobs = makeTestJobs(5, 1)
+    getJobsService = new FakeGetJobsService(jobs)
+    groupJobsService = new FakeGroupJobsService(jobs)
+  })
+
+  describe("fetchAndMergeNewRows", () => {
+    it("retrieves jobs", async () => {
+      const rowRequest = {
+        parentRowId: undefined,
+        skip: 0,
+        take: 2,
+      }
+
+      const existingData: JobTableRow[] = []
+      const aggregatableColumns: ColumnSpec[] = []
+      const groupedColumns: string[] = []
+
+      const result = await fetchAndMergeNewRows(
+        rowRequest,
+        existingData,
+        getJobsService,
+        groupJobsService,
+        aggregatableColumns,
+        groupedColumns,
+      )
+
+      expect(result).toStrictEqual({
+        rows: [
+          {
+            rowId: "job:0",
+            jobId: "0",
+            cpu: 4000,
+            ephemeralStorage: "32Gi",
+            jobSet: "job-set-1",
+            memory: "24Gi",
+            queue: "queue-1",
+            state: "Failed",
+          },
+          {
+            rowId: "job:1",
+            jobId: "1",
+            cpu: 4000,
+            ephemeralStorage: "32Gi",
+            jobSet: "job-set-2",
+            memory: "24Gi",
+            queue: "queue-2",
+            state: "Queued",
+          },
+        ],
+        updatedRootCount: 5,
+      })
+    })
+
+    it("retrieves groups", async () => {
+      const rowRequest = {
+        parentRowId: undefined,
+        skip: 0,
+        take: 2,
+      }
+
+      const existingData: JobTableRow[] = []
+      const aggregatableColumns: ColumnSpec[] = []
+      const groupedColumns: string[] = ["queue"]
+
+      const result = await fetchAndMergeNewRows(
+        rowRequest,
+        existingData,
+        getJobsService,
+        groupJobsService,
+        aggregatableColumns,
+        groupedColumns,
+      )
+
+      expect(result).toStrictEqual({
+        rows: [
+          { rowId: "queue:queue-1", queue: "queue-1", count: 1, isGroup: true, subRows: [] },
+          { rowId: "queue:queue-2", queue: "queue-2", count: 1, isGroup: true, subRows: [] },
+        ],
+        updatedRootCount: 5,
+      })
+    })
+
+    it("retrieves and merges jobs for expanded groups", async () => {
+      const rowRequest = {
+        parentRowId: "queue:queue-2",
+        skip: 0,
+        take: 2,
+      }
+
+      const existingData = [
+        { rowId: "queue:queue-1", queue: "queue-1", count: 1, isGroup: true, subRows: [] },
+        { rowId: "queue:queue-2", queue: "queue-2", count: 1, isGroup: true, subRows: [] },
+      ]
+      const aggregatableColumns: ColumnSpec[] = []
+      const groupedColumns: string[] = ["queue"]
+
+      const result = await fetchAndMergeNewRows(
+        rowRequest,
+        existingData,
+        getJobsService,
+        groupJobsService,
+        aggregatableColumns,
+        groupedColumns,
+      )
+
+      expect(result).toStrictEqual({
+        rows: [
+          { rowId: "queue:queue-1", queue: "queue-1", count: 1, isGroup: true, subRows: [] },
+          {
+            rowId: "queue:queue-2",
+            queue: "queue-2",
+            count: 1,
+            isGroup: true,
+            subRows: [
+              {
+                rowId: "job:1",
+                jobId: "1",
+                cpu: 4000,
+                ephemeralStorage: "32Gi",
+                jobSet: "job-set-2",
+                memory: "24Gi",
+                queue: "queue-2",
+                state: "Queued",
+              },
+            ],
+          },
+        ],
+        updatedRootCount: undefined,
+      })
+    })
+
+    it("retrieves and merges groups for expanded multi-level groups", async () => {
+      const rowRequest = {
+        parentRowId: "queue:queue-2",
+        skip: 0,
+        take: 2,
+      }
+
+      const existingData = [
+        { rowId: "queue:queue-1", queue: "queue-1", count: 1, isGroup: true, subRows: [] },
+        { rowId: "queue:queue-2", queue: "queue-2", count: 1, isGroup: true, subRows: [] },
+      ]
+      const aggregatableColumns: ColumnSpec[] = []
+      const groupedColumns: string[] = ["queue", "jobSet"]
+
+      const result = await fetchAndMergeNewRows(
+        rowRequest,
+        existingData,
+        getJobsService,
+        groupJobsService,
+        aggregatableColumns,
+        groupedColumns,
+      )
+
+      expect(result).toStrictEqual({
+        rows: [
+          { rowId: "queue:queue-1", queue: "queue-1", count: 1, isGroup: true, subRows: [] },
+          {
+            rowId: "queue:queue-2",
+            queue: "queue-2",
+            count: 1,
+            isGroup: true,
+            subRows: [
+              { rowId: "queue:queue-2>jobSet:job-set-2", jobSet: "job-set-2", count: 1, isGroup: true, subRows: [] },
+            ],
+          },
+        ],
+        updatedRootCount: undefined,
+      })
+    })
+  })
+})

--- a/src/utils/jobsTableUtils.test.ts
+++ b/src/utils/jobsTableUtils.test.ts
@@ -5,7 +5,7 @@ import GroupJobsService from "services/GroupJobsService"
 import FakeGetJobsService from "services/mocks/FakeGetJobsService"
 import FakeGroupJobsService from "services/mocks/FakeGroupJobsService"
 import { makeTestJobs } from "utils"
-import { fetchAndMergeNewRows, JobTableRow } from "./jobsTableUtils"
+import { fetchAndMergeNewRows, FetchRowRequest, JobTableRow } from "./jobsTableUtils"
 
 describe("JobsTableUtils", () => {
   let jobs: Job[], getJobsService: GetJobsService, groupJobsService: GroupJobsService
@@ -65,7 +65,7 @@ describe("JobsTableUtils", () => {
     })
 
     it("retrieves groups", async () => {
-      const rowRequest = {
+      const rowRequest: FetchRowRequest = {
         parentRowId: undefined,
         skip: 0,
         take: 2,
@@ -94,13 +94,13 @@ describe("JobsTableUtils", () => {
     })
 
     it("retrieves and merges jobs for expanded groups", async () => {
-      const rowRequest = {
+      const rowRequest: FetchRowRequest = {
         parentRowId: "queue:queue-2",
         skip: 0,
         take: 2,
       }
 
-      const existingData = [
+      const existingData: JobTableRow[] = [
         { rowId: "queue:queue-1", queue: "queue-1", count: 1, isGroup: true, subRows: [] },
         { rowId: "queue:queue-2", queue: "queue-2", count: 1, isGroup: true, subRows: [] },
       ]
@@ -143,13 +143,13 @@ describe("JobsTableUtils", () => {
     })
 
     it("retrieves and merges groups for expanded multi-level groups", async () => {
-      const rowRequest = {
+      const rowRequest: FetchRowRequest = {
         parentRowId: "queue:queue-2",
         skip: 0,
         take: 2,
       }
 
-      const existingData = [
+      const existingData: JobTableRow[] = [
         { rowId: "queue:queue-1", queue: "queue-1", count: 1, isGroup: true, subRows: [] },
         { rowId: "queue:queue-2", queue: "queue-2", count: 1, isGroup: true, subRows: [] },
       ]

--- a/src/utils/jobsTableUtils.test.ts
+++ b/src/utils/jobsTableUtils.test.ts
@@ -1,185 +1,43 @@
-import { Job } from "model"
-import { ColumnSpec } from "pages/JobsPage"
-import GetJobsService from "services/GetJobsService"
-import GroupJobsService from "services/GroupJobsService"
-import FakeGetJobsService from "services/mocks/FakeGetJobsService"
-import FakeGroupJobsService from "services/mocks/FakeGroupJobsService"
-import { makeTestJobs } from "utils"
-import { fetchAndMergeNewRows, FetchRowRequest, JobTableRow } from "./jobsTableUtils"
+import { convertExpandedRowFieldsToFilters } from "./jobsTableUtils";
 
 describe("JobsTableUtils", () => {
-  let jobs: Job[], getJobsService: GetJobsService, groupJobsService: GroupJobsService
+    describe("convertExpandedRowFieldsToFilters", () => {
+        it("returns empty if not expanding a row", () => {
+            const result = convertExpandedRowFieldsToFilters([]);
+            expect(result).toStrictEqual([]);
+        })
 
-  beforeEach(() => {
-    jobs = makeTestJobs(5, 1)
-    getJobsService = new FakeGetJobsService(jobs)
-    groupJobsService = new FakeGroupJobsService(jobs)
-  })
+        it("returns one filter when expanding a top level row", () => {
+            const result = convertExpandedRowFieldsToFilters([{ type: "queue", value: "queue-2" }]);
+            expect(result).toStrictEqual([
+                {
+                    field: "queue",
+                    value: "queue-2",
+                    match: "exact",
+                }
+            ]);
+        })
 
-  describe("fetchAndMergeNewRows", () => {
-    it("retrieves jobs", async () => {
-      const rowRequest = {
-        parentRowId: undefined,
-        skip: 0,
-        take: 2,
-      }
-
-      const existingData: JobTableRow[] = []
-      const aggregatableColumns: ColumnSpec[] = []
-      const groupedColumns: string[] = []
-
-      const result = await fetchAndMergeNewRows(
-        rowRequest,
-        existingData,
-        getJobsService,
-        groupJobsService,
-        aggregatableColumns,
-        groupedColumns,
-      )
-
-      expect(result).toStrictEqual({
-        rows: [
-          {
-            rowId: "job:0",
-            jobId: "0",
-            cpu: 4000,
-            ephemeralStorage: "32Gi",
-            jobSet: "job-set-1",
-            memory: "24Gi",
-            queue: "queue-1",
-            state: "Failed",
-          },
-          {
-            rowId: "job:1",
-            jobId: "1",
-            cpu: 4000,
-            ephemeralStorage: "32Gi",
-            jobSet: "job-set-2",
-            memory: "24Gi",
-            queue: "queue-2",
-            state: "Queued",
-          },
-        ],
-        updatedRootCount: 5,
-      })
+        it("returns multiple filters when expanding a nested row", () => {
+            const result = convertExpandedRowFieldsToFilters([
+                { type: "jobSet", value: "job-set-2" },
+                {
+                    type: "queue",
+                    value: "queue-2"
+                },
+            ]);
+            expect(result).toStrictEqual([
+                {
+                    field: "jobSet",
+                    value: "job-set-2",
+                    match: "exact",
+                },
+                {
+                    field: "queue",
+                    value: "queue-2",
+                    match: "exact",
+                }
+            ]);
+        })
     })
-
-    it("retrieves groups", async () => {
-      const rowRequest: FetchRowRequest = {
-        parentRowId: undefined,
-        skip: 0,
-        take: 2,
-      }
-
-      const existingData: JobTableRow[] = []
-      const aggregatableColumns: ColumnSpec[] = []
-      const groupedColumns: string[] = ["queue"]
-
-      const result = await fetchAndMergeNewRows(
-        rowRequest,
-        existingData,
-        getJobsService,
-        groupJobsService,
-        aggregatableColumns,
-        groupedColumns,
-      )
-
-      expect(result).toStrictEqual({
-        rows: [
-          { rowId: "queue:queue-1", queue: "queue-1", count: 1, isGroup: true, subRows: [] },
-          { rowId: "queue:queue-2", queue: "queue-2", count: 1, isGroup: true, subRows: [] },
-        ],
-        updatedRootCount: 5,
-      })
-    })
-
-    it("retrieves and merges jobs for expanded groups", async () => {
-      const rowRequest: FetchRowRequest = {
-        parentRowId: "queue:queue-2",
-        skip: 0,
-        take: 2,
-      }
-
-      const existingData: JobTableRow[] = [
-        { rowId: "queue:queue-1", queue: "queue-1", count: 1, isGroup: true, subRows: [] },
-        { rowId: "queue:queue-2", queue: "queue-2", count: 1, isGroup: true, subRows: [] },
-      ]
-      const aggregatableColumns: ColumnSpec[] = []
-      const groupedColumns: string[] = ["queue"]
-
-      const result = await fetchAndMergeNewRows(
-        rowRequest,
-        existingData,
-        getJobsService,
-        groupJobsService,
-        aggregatableColumns,
-        groupedColumns,
-      )
-
-      expect(result).toStrictEqual({
-        rows: [
-          { rowId: "queue:queue-1", queue: "queue-1", count: 1, isGroup: true, subRows: [] },
-          {
-            rowId: "queue:queue-2",
-            queue: "queue-2",
-            count: 1,
-            isGroup: true,
-            subRows: [
-              {
-                rowId: "job:1",
-                jobId: "1",
-                cpu: 4000,
-                ephemeralStorage: "32Gi",
-                jobSet: "job-set-2",
-                memory: "24Gi",
-                queue: "queue-2",
-                state: "Queued",
-              },
-            ],
-          },
-        ],
-        updatedRootCount: undefined,
-      })
-    })
-
-    it("retrieves and merges groups for expanded multi-level groups", async () => {
-      const rowRequest: FetchRowRequest = {
-        parentRowId: "queue:queue-2",
-        skip: 0,
-        take: 2,
-      }
-
-      const existingData: JobTableRow[] = [
-        { rowId: "queue:queue-1", queue: "queue-1", count: 1, isGroup: true, subRows: [] },
-        { rowId: "queue:queue-2", queue: "queue-2", count: 1, isGroup: true, subRows: [] },
-      ]
-      const aggregatableColumns: ColumnSpec[] = []
-      const groupedColumns: string[] = ["queue", "jobSet"]
-
-      const result = await fetchAndMergeNewRows(
-        rowRequest,
-        existingData,
-        getJobsService,
-        groupJobsService,
-        aggregatableColumns,
-        groupedColumns,
-      )
-
-      expect(result).toStrictEqual({
-        rows: [
-          { rowId: "queue:queue-1", queue: "queue-1", count: 1, isGroup: true, subRows: [] },
-          {
-            rowId: "queue:queue-2",
-            queue: "queue-2",
-            count: 1,
-            isGroup: true,
-            subRows: [
-              { rowId: "queue:queue-2>jobSet:job-set-2", jobSet: "job-set-2", count: 1, isGroup: true, subRows: [] },
-            ],
-          },
-        ],
-        updatedRootCount: undefined,
-      })
-    })
-  })
 })

--- a/src/utils/jobsTableUtils.ts
+++ b/src/utils/jobsTableUtils.ts
@@ -139,18 +139,12 @@ export const fetchAndMergeNewRows = async (
   selectedColumns: ColumnSpec[],
   currentGroupedColumns: string[],
 ): Promise<FetchAndMergeNewRowsResult> => {
-  const response = await fetchRows(
-    rowRequest,
-    getJobsService,
-    groupJobsService,
-    selectedColumns,
-    currentGroupedColumns,
-  );
+  const response = await fetchRows(rowRequest, getJobsService, groupJobsService, selectedColumns, currentGroupedColumns)
 
   // Just return if this is the top-level data
-  const parentToFind = rowRequest.parentRowId;
+  const parentToFind = rowRequest.parentRowId
   if (!parentToFind) {
-    return { rows: response.rows, updatedRootCount: response.totalCount };
+    return { rows: response.rows, updatedRootCount: response.totalCount }
   }
 
   // Otherwise merge it into existing data

--- a/src/utils/jobsTableUtils.ts
+++ b/src/utils/jobsTableUtils.ts
@@ -1,44 +1,51 @@
-import { Job, JobGroup, JobFilter, JobOrder } from "model"
-import { ColumnSpec } from "pages/JobsPage"
+import { Job, JobFilter, JobGroup, JobOrder } from "model"
+import { JobRow, JobGroupRow } from "models/jobsTableModels"
 import GetJobsService from "services/GetJobsService"
 import GroupJobsService from "services/GroupJobsService"
-import { fromRowId, RowId, RowIdSegment, toRowId } from "./reactTableUtils"
+import { RowIdParts, toRowId, RowId } from "./reactTableUtils"
 
-export interface BaseJobTableRow {
-  rowId: RowId
+export const convertExpandedRowFieldsToFilters = (expandedRowIdParts: RowIdParts[]): JobFilter[] => {
+  const filters: JobFilter[] = expandedRowIdParts.map(({ type, value }) => ({
+    field: type,
+    value,
+    match: "exact",
+  }))
+
+  return filters;
 }
-
-export interface JobRow extends BaseJobTableRow {
-  // Job details
-  jobId?: string
-  jobSet?: string
-  queue?: string
-  state?: string
-  cpu?: number
-  memory?: string
-  ephemeralStorage?: string
-}
-
-export interface JobGroupRow extends BaseJobTableRow {
-  isGroup: true // The ReactTable version of this doesn't seem to play nice with manual/serverside expanding
-  count?: number
-  subRows?: JobTableRow[]
-
-  // Some subfield of JobRow that this row is grouped on
-  [groupedField: string]: unknown
-}
-
-export type JobTableRow = JobRow | JobGroupRow
-
-export const isJobGroupRow = (row: JobTableRow): row is JobGroupRow => "isGroup" in row
 
 export interface FetchRowRequest {
-  parentRowId: RowId | undefined // Undefined means root rows
+  filters: JobFilter[]
   skip: number
   take: number
 }
+export const fetchJobs = async (rowRequest: FetchRowRequest, getJobsService: GetJobsService) => {
+  const { filters, skip, take } = rowRequest
 
-function jobsToRows(jobs: Job[]): JobRow[] {
+  const order: JobOrder = { field: "jobId", direction: "ASC" }
+  return await getJobsService.getJobs(filters, order, skip, take, undefined)
+}
+
+export const fetchJobGroups = async (
+  rowRequest: FetchRowRequest,
+  groupJobsService: GroupJobsService,
+  groupedColumn: string,
+  columnsToAggregate: string[]) => {
+  const { filters, skip, take } = rowRequest
+
+  const order: JobOrder = { field: "name", direction: "ASC" }
+  return await groupJobsService.groupJobs(
+    filters,
+    order,
+    groupedColumn,
+    columnsToAggregate,
+    skip,
+    take,
+    undefined,
+  )
+}
+
+export const jobsToRows = (jobs: Job[]): JobRow[] => {
   return jobs.map(
     (job): JobRow => ({
       rowId: toRowId({ type: "job", value: job.jobId }),
@@ -53,7 +60,7 @@ function jobsToRows(jobs: Job[]): JobRow[] {
   )
 }
 
-function groupsToRows(groups: JobGroup[], baseRowId: RowId | undefined, groupingField: string): JobGroupRow[] {
+export const groupsToRows = (groups: JobGroup[], baseRowId: RowId | undefined, groupingField: string): JobGroupRow[] => {
   return groups.map(
     (group): JobGroupRow => ({
       rowId: toRowId({ type: groupingField, value: group.name, parentRowId: baseRowId }),
@@ -64,119 +71,4 @@ function groupsToRows(groups: JobGroup[], baseRowId: RowId | undefined, grouping
       subRows: [], // Will be set later if expanded
     }),
   )
-}
-
-interface FetchRowsResult {
-  rows: JobRow[]
-  totalCount: number
-}
-const fetchRows = async (
-  rowRequest: FetchRowRequest,
-  getJobsService: GetJobsService,
-  groupJobsService: GroupJobsService,
-  selectedColumns: ColumnSpec[],
-  currentGroupedColumns: string[],
-): Promise<FetchRowsResult> => {
-  const { parentRowId, skip, take } = rowRequest
-  const parentInfo = parentRowId ? fromRowId(parentRowId) : undefined
-
-  const groupingLevel = currentGroupedColumns.length
-  const expandedLevel = parentInfo ? parentInfo.rowIdPathFromRoot.length + 1 : 0
-
-  console.log({ groupingLevel, expandedLevel, parentInfo })
-
-  if (groupingLevel === expandedLevel) {
-    // Time to request jobs
-    const filters: JobFilter[] =
-      parentRowId
-        ?.split(">")
-        .map((s) => s.split(":"))
-        .map(([field, value]) => ({
-          field,
-          value,
-          match: "exact",
-        })) ?? []
-
-    const order: JobOrder = { field: "jobId", direction: "ASC" }
-    const { jobs, totalJobs } = await getJobsService.getJobs(filters, order, skip, take, undefined)
-
-    const newJobRows = jobsToRows(jobs)
-
-    return { rows: newJobRows, totalCount: totalJobs }
-  } else {
-    // Need to request groups, filtered to current
-    const fields = parentRowId?.split(">").map((s) => s.split(":")) ?? []
-
-    const filters: JobFilter[] = fields.map(([filterField, filterValue]) => ({
-      field: filterField,
-      value: filterValue,
-      match: "exact",
-    }))
-
-    const order: JobOrder = { field: "name", direction: "ASC" }
-    const groupingField = currentGroupedColumns[expandedLevel]
-    const { groups, totalGroups } = await groupJobsService.groupJobs(
-      filters,
-      order,
-      groupingField,
-      selectedColumns.filter((c) => c.groupable).map((c) => c.key),
-      skip,
-      take,
-      undefined,
-    )
-
-    const newGroupRows = groupsToRows(groups, parentRowId, groupingField)
-    return { rows: newGroupRows, totalCount: totalGroups }
-  }
-}
-
-export const mergeRows = (existingData: JobTableRow[], newRows: FetchRowsResult, parentRowsPath: RowIdSegment[]) => {
-  // Just return if this is the top-level data
-  // const parentToFind = rowRequest.parentRowId
-  if (parentRowsPath.length === 0) {
-    return { rows: newRows.rows, updatedRootCount: newRows.totalCount }
-  }
-
-  // Otherwise merge it into existing data
-  const rowIdsPathForParent = parentRowsPath.reduce<string[]>((paths, newLevel) => {
-    const prev = paths.length > 0 ? paths[paths.length - 1] : undefined
-    return paths.concat([(prev ? prev + ">" : "") + newLevel])
-  }, [])
-
-  const rowToModify: JobGroupRow | undefined = rowIdsPathForParent.reduce<JobGroupRow | undefined>(
-    (row, rowIdToFind) => {
-      const candidateRow = row?.subRows?.find((r) => r.rowId === rowIdToFind)
-      if (candidateRow && isJobGroupRow(candidateRow)) {
-        return candidateRow
-      }
-    },
-    { subRows: existingData } as JobGroupRow,
-  )
-
-  // Modifies in-place for now
-  if (rowToModify) {
-    rowToModify.subRows = newRows.rows
-  } else {
-    console.warn("Could not find row to merge with path. This is a bug.", rowIdsPathForParent)
-  }
-
-  return { rows: [...existingData], updatedRootCount: undefined }
-}
-
-export type FetchAndMergeNewRowsResult = {
-  rows: JobTableRow[]
-  updatedRootCount?: number
-}
-export const fetchAndMergeNewRows = async (
-  rowRequest: FetchRowRequest,
-  existingData: JobTableRow[],
-  getJobsService: GetJobsService,
-  groupJobsService: GroupJobsService,
-  selectedColumns: ColumnSpec[],
-  currentGroupedColumns: string[],
-): Promise<FetchAndMergeNewRowsResult> => {
-  const response = await fetchRows(rowRequest, getJobsService, groupJobsService, selectedColumns, currentGroupedColumns)
-
-  const parentRowsPath = (rowRequest.parentRowId?.split(">") as RowIdSegment[]) ?? []
-  return mergeRows(existingData, response, parentRowsPath)
 }

--- a/src/utils/reactTableUtils.test.ts
+++ b/src/utils/reactTableUtils.test.ts
@@ -1,0 +1,61 @@
+import { fromRowId, toRowId } from "./reactTableUtils"
+
+describe("ReactTableUtils", () => {
+  const baseRowIdExample = "job:0"
+  const childRowIdExample = "queue:queue-2>job:0"
+  const deeplyNestedRowIdExample = "jobSet:job-set-2>queue:queue-2>job:0"
+
+  describe("toRowId", () => {
+    it("returns base row ID format", () => {
+      const result = toRowId({
+        type: "job",
+        value: "0",
+      })
+      expect(result).toBe(baseRowIdExample)
+    })
+
+    it("returns child row ID format", () => {
+      const result = toRowId({
+        type: "job",
+        value: "0",
+        parentRowId: "queue:queue-2",
+      })
+      expect(result).toBe(childRowIdExample)
+    })
+
+    it("returns deeply nested row ID format", () => {
+      const result = toRowId({
+        type: "job",
+        value: "0",
+        parentRowId: "jobSet:job-set-2>queue:queue-2",
+      })
+      expect(result).toBe(deeplyNestedRowIdExample)
+    })
+  })
+
+  describe("fromRowId", () => {
+    it("handles base row ID format", () => {
+      const result = fromRowId(baseRowIdExample)
+      expect(result).toStrictEqual({
+        rowIdPartsPath: [{type: 'job', value: '0'}],
+        rowIdPathFromRoot: ['job:0']
+      })
+    })
+
+    it("handles child row ID format", () => {
+      const result = fromRowId(childRowIdExample)
+      expect(result).toStrictEqual({
+        rowIdPartsPath: [{type: "queue", value: "queue-2"}, {type: 'job', value: '0'}],
+        rowIdPathFromRoot: ["queue:queue-2", 'queue:queue-2>job:0']
+      })
+    })
+
+    it("handles deeply nested row ID format", () => {
+      const result = fromRowId(deeplyNestedRowIdExample)
+      expect(result).toStrictEqual({
+        rowIdPartsPath: [{type: "jobSet", value: "job-set-2"}, {type: "queue", value: "queue-2"}, {type: 'job', value: '0'}],
+        rowIdPathFromRoot: ["jobSet:job-set-2", "jobSet:job-set-2>queue:queue-2", 'jobSet:job-set-2>queue:queue-2>job:0']
+      })
+    })
+  })
+})

--- a/src/utils/reactTableUtils.test.ts
+++ b/src/utils/reactTableUtils.test.ts
@@ -1,61 +1,111 @@
-import { fromRowId, toRowId } from "./reactTableUtils"
+import { fromRowId, mergeSubRows, RowId, RowWithOptionalSubRows, toRowId } from "./reactTableUtils"
 
 describe("ReactTableUtils", () => {
-  const baseRowIdExample = "job:0"
-  const childRowIdExample = "queue:queue-2>job:0"
-  const deeplyNestedRowIdExample = "jobSet:job-set-2>queue:queue-2>job:0"
+  describe("Row IDs", () => {
+    const baseRowIdExample = "job:0"
+    const childRowIdExample = "queue:queue-2>job:0"
+    const deeplyNestedRowIdExample = "jobSet:job-set-2>queue:queue-2>job:0"
 
-  describe("toRowId", () => {
-    it("returns base row ID format", () => {
-      const result = toRowId({
-        type: "job",
-        value: "0",
+    describe("toRowId", () => {
+        it("returns base row ID format", () => {
+          const result = toRowId({
+            type: "job",
+            value: "0",
+          })
+          expect(result).toBe(baseRowIdExample)
+        })
+    
+        it("returns child row ID format", () => {
+          const result = toRowId({
+            type: "job",
+            value: "0",
+            parentRowId: "queue:queue-2",
+          })
+          expect(result).toBe(childRowIdExample)
+        })
+    
+        it("returns deeply nested row ID format", () => {
+          const result = toRowId({
+            type: "job",
+            value: "0",
+            parentRowId: "jobSet:job-set-2>queue:queue-2",
+          })
+          expect(result).toBe(deeplyNestedRowIdExample)
+        })
       })
-      expect(result).toBe(baseRowIdExample)
-    })
-
-    it("returns child row ID format", () => {
-      const result = toRowId({
-        type: "job",
-        value: "0",
-        parentRowId: "queue:queue-2",
+    
+      describe("fromRowId", () => {
+        it("handles base row ID format", () => {
+          const result = fromRowId(baseRowIdExample)
+          expect(result).toStrictEqual({
+            rowId: baseRowIdExample,
+            rowIdPartsPath: [{type: 'job', value: '0'}],
+            rowIdPathFromRoot: ['job:0']
+          })
+        })
+    
+        it("handles child row ID format", () => {
+          const result = fromRowId(childRowIdExample)
+          expect(result).toStrictEqual({
+            rowId: childRowIdExample,
+            rowIdPartsPath: [{type: "queue", value: "queue-2"}, {type: 'job', value: '0'}],
+            rowIdPathFromRoot: ["queue:queue-2", 'queue:queue-2>job:0']
+          })
+        })
+    
+        it("handles deeply nested row ID format", () => {
+          const result = fromRowId(deeplyNestedRowIdExample)
+          expect(result).toStrictEqual({
+            rowId: deeplyNestedRowIdExample,
+            rowIdPartsPath: [{type: "jobSet", value: "job-set-2"}, {type: "queue", value: "queue-2"}, {type: 'job', value: '0'}],
+            rowIdPathFromRoot: ["jobSet:job-set-2", "jobSet:job-set-2>queue:queue-2", 'jobSet:job-set-2>queue:queue-2>job:0']
+          })
+        })
       })
-      expect(result).toBe(childRowIdExample)
-    })
-
-    it("returns deeply nested row ID format", () => {
-      const result = toRowId({
-        type: "job",
-        value: "0",
-        parentRowId: "jobSet:job-set-2>queue:queue-2",
-      })
-      expect(result).toBe(deeplyNestedRowIdExample)
-    })
   })
 
-  describe("fromRowId", () => {
-    it("handles base row ID format", () => {
-      const result = fromRowId(baseRowIdExample)
-      expect(result).toStrictEqual({
-        rowIdPartsPath: [{type: 'job', value: '0'}],
-        rowIdPathFromRoot: ['job:0']
-      })
+  describe("mergeSubRows", () => {
+    let existingData: RowWithOptionalSubRows[], 
+        newRows: RowWithOptionalSubRows[],
+        locationForSubRows: RowId[];
+
+    it('returns given rows if no parent path given', () => {
+        existingData = [{rowId: "fruit:apple"}];
+        newRows = [{rowId: "fruit:banana"}];
+        locationForSubRows = [];
+        const result = mergeSubRows(existingData, newRows, locationForSubRows);
+        expect(result).toStrictEqual(newRows);
     })
 
-    it("handles child row ID format", () => {
-      const result = fromRowId(childRowIdExample)
-      expect(result).toStrictEqual({
-        rowIdPartsPath: [{type: "queue", value: "queue-2"}, {type: 'job', value: '0'}],
-        rowIdPathFromRoot: ["queue:queue-2", 'queue:queue-2>job:0']
-      })
+    it('merges in new rows at the correct location', () => {
+        existingData = [
+            {rowId: "fruit:apple", subRows: []},
+            {rowId: "fruit:banana", subRows: []}
+        ];
+        newRows = [{rowId: "taste:delicious"}];
+        locationForSubRows = ["fruit:banana"];
+
+        const result = mergeSubRows(existingData, newRows, locationForSubRows);
+
+        expect(result).toStrictEqual([
+            {rowId: "fruit:apple", subRows: []},
+            {rowId: "fruit:banana", subRows: [
+                {rowId: "taste:delicious"}
+            ]}
+        ]);
     })
 
-    it("handles deeply nested row ID format", () => {
-      const result = fromRowId(deeplyNestedRowIdExample)
-      expect(result).toStrictEqual({
-        rowIdPartsPath: [{type: "jobSet", value: "job-set-2"}, {type: "queue", value: "queue-2"}, {type: 'job', value: '0'}],
-        rowIdPathFromRoot: ["jobSet:job-set-2", "jobSet:job-set-2>queue:queue-2", 'jobSet:job-set-2>queue:queue-2>job:0']
-      })
+    it('does not crash if merging failed', () => {
+        existingData = [
+            {rowId: "fruit:apple", subRows: []},
+            {rowId: "fruit:banana", subRows: []}
+        ];
+        newRows = [{rowId: "taste:delicious"}];
+        locationForSubRows = ["fruit:avocado"];
+
+        const result = mergeSubRows(existingData, newRows, locationForSubRows);
+        
+        expect(result).toStrictEqual(existingData);
     })
   })
 })

--- a/src/utils/reactTableUtils.ts
+++ b/src/utils/reactTableUtils.ts
@@ -1,0 +1,47 @@
+// E.g. "job:1", or "queue:queue-2"
+// Format comes from ReactTable grouping, see https://github.com/TanStack/table/blob/main/packages/table-core/src/utils/getGroupedRowModel.ts#L59
+// It's convenient to just use this same format everywhere
+export type RowIdSegment = `${string}:${string}`
+
+// E.g. "job:1", or "jobSet:job-set-2>job:1"
+// Format comes from ReactTable grouping, see https://github.com/TanStack/table/blob/main/packages/table-core/src/utils/getGroupedRowModel.ts#L60
+export type RowId = RowIdSegment | `${RowIdSegment}>${RowIdSegment}`
+
+export type RowIdParts = {
+  type: string
+  value: string
+  parentRowId?: RowId
+}
+export const toRowId = ({ type, value, parentRowId }: RowIdParts): RowId => {
+  const rowIdSegment: RowIdSegment = `${type}:${value}`
+  return parentRowId ? `${parentRowId}>${rowIdSegment}` : rowIdSegment
+}
+
+export type RowIdInfo = {
+  // Provides key-value info on each part of this row's hierarchy position
+  // E.g. [{type: "queue", value: "queue-2"}, {type: "jobSet", value: "job-set-2"}]
+  rowIdPartsPath: RowIdParts[]
+
+  // Helper to allow easier navigation of grouped ReactTable data
+  // E.g. ["queue:queue-2", "queue:queue-2>jobSet:job-set-2"]
+  rowIdPathFromRoot: RowId[]
+}
+export const fromRowId = (rowId: RowId): RowIdInfo => {
+  const rowIdSegments: RowIdSegment[] = rowId.split(">") as RowIdSegment[]
+
+  const rowIdPartsPath = rowIdSegments.map(segment => {
+    const [type, value] = segment.split(":");
+    return {type, value};
+  })
+
+  let lastRowId: RowId | undefined = undefined
+  const rowIdPathFromRoot: RowId[] = rowIdPartsPath.map(({type, value}) => {
+    lastRowId = toRowId({type, value, parentRowId: lastRowId});
+    return lastRowId
+  })
+
+  return {
+    rowIdPartsPath,
+    rowIdPathFromRoot,
+  }
+}


### PR DESCRIPTION
- Moves generic ReactTable-specific logic into `reactTableUtils.ts` and adds tests
- Introduces stricter typing & utilities for Row IDs
- Pulls a bit more logic into the component as the layer of abstraction was becoming awkward
- Assumes we're only making a single fetch request at once (removing the `Promise.all`) that was called out in the previous PR