### PR TITLE
Move grouping into table action bar

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,7 +12,11 @@ module.exports = {
       version: "detect",
     },
   },
-  extends: ["plugin:react/recommended", "plugin:@typescript-eslint/recommended", "prettier"],
+  extends: [
+    "plugin:react/recommended", 
+    "plugin:@typescript-eslint/recommended", 
+    "prettier"
+  ],
   plugins: ["prettier", "eslint-plugin-import"],
   rules: {
     "prettier/prettier": [
@@ -27,11 +31,13 @@ module.exports = {
     "react/display-name": "off",
     "@typescript-eslint/no-unused-vars": [
       "warn",
-      { 
+      {
         "argsIgnorePattern": "^_",
         "varsIgnorePattern": "^_",
         "caughtErrorsIgnorePattern": "^_"
       }
-    ]
+    ],
+    // Not needed with react-jsx
+    "react/react-in-jsx-scope": "off",
   },
 }

--- a/src/components/ColumnSelect.tsx
+++ b/src/components/ColumnSelect.tsx
@@ -13,14 +13,16 @@ import {
   OutlinedInput,
   Select,
   TextField,
+  Tooltip,
   Typography,
 } from "@mui/material"
 
 import styles from "./ColumnSelect.module.css"
-import { ColumnSpec } from "utils/jobsTableColumns"
+import { ColumnId, ColumnSpec } from "utils/jobsTableColumns"
 
 type ColumnSelectProps = {
   allColumns: ColumnSpec[]
+  groupedColumns: ColumnId[]
   onAddAnnotation: (annotationKey: string) => void
   onToggleColumn: (columnKey: string) => void
   onRemoveAnnotation: (columnKey: string) => void
@@ -29,6 +31,7 @@ type ColumnSelectProps = {
 
 export default function ColumnSelect({
   allColumns,
+  groupedColumns,
   onAddAnnotation,
   onToggleColumn,
   onRemoveAnnotation,
@@ -82,69 +85,76 @@ export default function ColumnSelect({
             className={styles.columnMenu}
           >
             <div className={styles.columnSelect} style={{ height: "100%" }}>
-              {allColumns.map((column) => (
-                <MenuItem key={column.key} value={column.name}>
-                  <Checkbox checked={column.selected} onClick={() => onToggleColumn(column.key)} />
-                  {column.isAnnotation ? (
-                    <>
-                      {currentlyEditing.has(column.key) ? (
-                        <>
-                          <TextField
-                            label="Annotation Key"
-                            size="small"
-                            variant="standard"
-                            value={currentlyEditing.get(column.key)}
-                            onChange={(e) => edit(column.key, e.target.value)}
-                            style={{
-                              maxWidth: 350,
-                            }}
-                            fullWidth={true}
-                          />
-                          <IconButton
-                            onClick={() => {
-                              if (currentlyEditing.has(column.key)) {
-                                onEditAnnotation(column.key, currentlyEditing.get(column.key) ?? "")
-                              }
-                              stopEditing(column.key)
-                            }}
-                          >
-                            <Check />
-                          </IconButton>
-                        </>
-                      ) : (
-                        <>
-                          <ListItemText
-                            primary={column.name}
-                            style={{
-                              maxWidth: 350,
-                              overflowX: "auto",
-                            }}
-                          />
-                          <IconButton onClick={() => edit(column.key, column.name)}>
-                            <Edit />
-                          </IconButton>
-                        </>
-                      )}
-                      <IconButton
-                        onClick={() => {
-                          stopEditing(column.key)
-                          onRemoveAnnotation(column.key)
+              {allColumns.map((column) => {
+                const colIsGrouped = groupedColumns.includes(column.key);
+                return (
+                  <MenuItem
+                    key={column.key}
+                    value={column.name}
+                    disabled={colIsGrouped}
+                  >
+                    <Checkbox checked={column.selected} onClick={() => onToggleColumn(column.key)} />
+                    {column.isAnnotation ? (
+                      <>
+                        {currentlyEditing.has(column.key) ? (
+                          <>
+                            <TextField
+                              label="Annotation Key"
+                              size="small"
+                              variant="standard"
+                              value={currentlyEditing.get(column.key)}
+                              onChange={(e) => edit(column.key, e.target.value)}
+                              style={{
+                                maxWidth: 350,
+                              }}
+                              fullWidth={true}
+                            />
+                            <IconButton
+                              onClick={() => {
+                                if (currentlyEditing.has(column.key)) {
+                                  onEditAnnotation(column.key, currentlyEditing.get(column.key) ?? "")
+                                }
+                                stopEditing(column.key)
+                              }}
+                            >
+                              <Check />
+                            </IconButton>
+                          </>
+                        ) : (
+                          <>
+                            <ListItemText
+                              primary={column.name}
+                              style={{
+                                maxWidth: 350,
+                                overflowX: "auto",
+                              }}
+                            />
+                            <IconButton onClick={() => edit(column.key, column.name)}>
+                              <Edit />
+                            </IconButton>
+                          </>
+                        )}
+                        <IconButton
+                          onClick={() => {
+                            stopEditing(column.key)
+                            onRemoveAnnotation(column.key)
+                          }}
+                        >
+                          <Delete />
+                        </IconButton>
+                      </>
+                    ) : (
+                      <ListItemText
+                        primary={column.name + (colIsGrouped ? " (Grouped)" : "")}
+                        style={{
+                          maxWidth: 350,
+                          overflowX: "auto",
                         }}
-                      >
-                        <Delete />
-                      </IconButton>
-                    </>
-                  ) : (
-                    <ListItemText
-                      primary={column.name}
-                      style={{
-                        maxWidth: 350,
-                        overflowX: "auto",
-                      }}
-                    />
-                  )}
-                </MenuItem>
-              ))}
+                      />
+                    )}
+                  </MenuItem>
+                )
+              })}
             </div>
             <Divider orientation="vertical" style={{ height: "100%" }} />
             <div className={styles.annotationSelectContainer}>

--- a/src/components/ColumnSelect.tsx
+++ b/src/components/ColumnSelect.tsx
@@ -20,7 +20,7 @@ import styles from "./ColumnSelect.module.css"
 import { ColumnSpec } from "utils/jobsTableColumns"
 
 type ColumnSelectProps = {
-  columns: ColumnSpec[]
+  allColumns: ColumnSpec[]
   onAddAnnotation: (annotationKey: string) => void
   onToggleColumn: (columnKey: string) => void
   onRemoveAnnotation: (columnKey: string) => void
@@ -28,7 +28,7 @@ type ColumnSelectProps = {
 }
 
 export default function ColumnSelect({
-  columns,
+  allColumns,
   onAddAnnotation,
   onToggleColumn,
   onRemoveAnnotation,
@@ -71,7 +71,7 @@ export default function ColumnSelect({
           labelId="checkbox-select-label"
           id="demo-multiple-checkbox"
           multiple
-          value={columns.map((col) => col.selected)}
+          value={allColumns.filter((col) => col.selected)}
           input={<OutlinedInput label="Column" />}
           renderValue={(selected) => {
             return `${selected.length} columns selected`
@@ -82,7 +82,7 @@ export default function ColumnSelect({
             className={styles.columnMenu}
           >
             <div className={styles.columnSelect} style={{ height: "100%" }}>
-              {columns.map((column) => (
+              {allColumns.map((column) => (
                 <MenuItem key={column.key} value={column.name}>
                   <Checkbox checked={column.selected} onClick={() => onToggleColumn(column.key)} />
                   {column.isAnnotation ? (

--- a/src/components/ColumnSelect.tsx
+++ b/src/components/ColumnSelect.tsx
@@ -65,7 +65,7 @@ export default function ColumnSelect({
 
   return (
     <>
-      <FormControl sx={{ m: 0, width: 200 }}>
+      <FormControl sx={{ m: 0, width: 200 }} focused={false}>
         <InputLabel id="checkbox-select-label">Columns</InputLabel>
         <Select
           labelId="checkbox-select-label"

--- a/src/components/ColumnSelect.tsx
+++ b/src/components/ColumnSelect.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react"
+import { useState } from "react"
 
 import { Check, Delete, Edit } from "@mui/icons-material"
 import {
@@ -13,7 +13,6 @@ import {
   OutlinedInput,
   Select,
   TextField,
-  Tooltip,
   Typography,
 } from "@mui/material"
 
@@ -81,18 +80,12 @@ export default function ColumnSelect({
           }}
           size="small"
         >
-          <div
-            className={styles.columnMenu}
-          >
+          <div className={styles.columnMenu}>
             <div className={styles.columnSelect} style={{ height: "100%" }}>
               {allColumns.map((column) => {
-                const colIsGrouped = groupedColumns.includes(column.key);
+                const colIsGrouped = groupedColumns.includes(column.key)
                 return (
-                  <MenuItem
-                    key={column.key}
-                    value={column.name}
-                    disabled={colIsGrouped}
-                  >
+                  <MenuItem key={column.key} value={column.name} disabled={colIsGrouped}>
                     <Checkbox checked={column.selected} onClick={() => onToggleColumn(column.key)} />
                     {column.isAnnotation ? (
                       <>

--- a/src/components/ColumnSelect.tsx
+++ b/src/components/ColumnSelect.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from "react"
 
 import { Check, Delete, Edit } from "@mui/icons-material"
-import ViewColumnOutlinedIcon from "@mui/icons-material/ViewColumnOutlined"
 import {
   Button,
   Checkbox,
@@ -20,11 +19,7 @@ import {
 import styles from "./ColumnSelect.module.css"
 import { ColumnSpec } from "utils/jobsTableColumns"
 
-const ITEM_HEIGHT = 54
-const MENU_PADDING = 8
-
 type ColumnSelectProps = {
-  height: number
   columns: ColumnSpec[]
   onAddAnnotation: (annotationKey: string) => void
   onToggleColumn: (columnKey: string) => void
@@ -33,7 +28,6 @@ type ColumnSelectProps = {
 }
 
 export default function ColumnSelect({
-  height,
   columns,
   onAddAnnotation,
   onToggleColumn,
@@ -69,11 +63,8 @@ export default function ColumnSelect({
     }
   }
 
-  const menuHeight = ITEM_HEIGHT * Math.min(12, columns.length)
-
   return (
     <>
-      <ViewColumnOutlinedIcon />
       <FormControl sx={{ m: 0, width: 200 }}>
         <InputLabel id="checkbox-select-label">Columns</InputLabel>
         <Select
@@ -85,21 +76,10 @@ export default function ColumnSelect({
           renderValue={(selected) => {
             return `${selected.length} columns selected`
           }}
-          MenuProps={{
-            PaperProps: {
-              style: {
-                height: menuHeight + 2 * MENU_PADDING,
-                maxWidth: 750,
-              },
-            },
-          }}
-          sx={{ maxHeight: height }}
+          size="small"
         >
           <div
             className={styles.columnMenu}
-            style={{
-              height: menuHeight,
-            }}
           >
             <div className={styles.columnSelect} style={{ height: "100%" }}>
               {columns.map((column) => (

--- a/src/components/GroupBySelect.module.css
+++ b/src/components/GroupBySelect.module.css
@@ -1,18 +1,21 @@
 .container {
-    align-self: stretch;
     display: flex;
     flex-direction: row;
     align-items: center;
+
     padding-left: 5px;
     padding-right: 5px;
 }
 
 .groupByElement {
+    align-self: stretch;
+
     display: flex;
     flex-direction: row;
     align-items: center;
-    align-self: stretch;
+
     padding: 5px;
+
     border-width: 1px;
     border-style: solid;
     border-radius: 5px;

--- a/src/components/GroupBySelect.module.css
+++ b/src/components/GroupBySelect.module.css
@@ -1,5 +1,5 @@
 .container {
-    height: 100%;
+    align-self: stretch;
     display: flex;
     flex-direction: row;
     align-items: center;
@@ -11,6 +11,7 @@
     display: flex;
     flex-direction: row;
     align-items: center;
+    align-self: stretch;
     padding: 5px;
     border-width: 1px;
     border-style: solid;

--- a/src/components/GroupBySelect.tsx
+++ b/src/components/GroupBySelect.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 
 import { Clear } from "@mui/icons-material"
-import { Divider, FormControl, IconButton, InputLabel, MenuItem, OutlinedInput, Select, TextField } from "@mui/material"
+import { Divider, FormControl, IconButton, InputLabel, MenuItem, OutlinedInput, Select } from "@mui/material"
 
 import styles from "./GroupBySelect.module.css"
 import { ColumnId, ColumnSpec } from "utils/jobsTableColumns"
@@ -18,15 +18,12 @@ interface GroupColumnProps {
   onDelete: () => void
 }
 function GroupColumn({ columns, currentlySelected, onSelect, onDelete }: GroupColumnProps) {
-  const isGrouped = currentlySelected !== "";
-  const actionText = isGrouped ? 'Grouped by' : 'Group by';
-  const labelId = `select-column-group-${currentlySelected}`;
+  const isGrouped = currentlySelected !== ""
+  const actionText = isGrouped ? "Grouped by" : "Group by"
+  const labelId = `select-column-group-${currentlySelected}`
   return (
     <FormControl size="small" focused={false}>
-      <InputLabel
-        id={labelId}
-        size="small"
-      >
+      <InputLabel id={labelId} size="small">
         {actionText}
       </InputLabel>
       <Select
@@ -36,14 +33,18 @@ function GroupColumn({ columns, currentlySelected, onSelect, onDelete }: GroupCo
         sx={{
           minWidth: 110,
           paddingRight: "0.5em",
-          "& .MuiSelect-iconOutlined": { display: isGrouped ? 'none' : '' }
+
+          // Only show the dropdown arrow if the clear icon isn't being shown
+          "& .MuiSelect-iconOutlined": { display: isGrouped ? "none" : "" },
         }}
         input={<OutlinedInput label={actionText} />}
-        endAdornment={(isGrouped &&
-          <IconButton size="small" sx={{ padding: 0 }} onClick={onDelete}>
-            <Clear aria-label="Clear grouping" aria-hidden="false"/>
-          </IconButton>
-        )}
+        endAdornment={
+          isGrouped && (
+            <IconButton size="small" sx={{ padding: 0 }} onClick={onDelete}>
+              <Clear aria-label="Clear grouping" aria-hidden="false" />
+            </IconButton>
+          )
+        }
       >
         {columns.map((col) => (
           <MenuItem
@@ -66,14 +67,14 @@ export interface GroupBySelectProps {
   onGroupsChanged: (newGroups: ColumnId[]) => void
 }
 export default function GroupBySelect({ groups, columns, onGroupsChanged }: GroupBySelectProps) {
-  const groupableColumns = columns.filter(isGroupable);
-  const ungroupedColumns = groupableColumns.filter(c => !groups.includes(c.key))
+  const groupableColumns = columns.filter(isGroupable)
+  const ungroupedColumns = groupableColumns.filter((c) => !groups.includes(c.key))
   return (
     <div className={styles.container}>
       {/* Controls to modify/remove selected groups */}
       {groups.map((key, i) => {
         const alreadyListed = groups.slice(0, i)
-        const remainingOptions = groupableColumns.filter(c => !alreadyListed.includes(c.key))
+        const remainingOptions = groupableColumns.filter((c) => !alreadyListed.includes(c.key))
         return (
           <React.Fragment key={key}>
             <GroupColumn
@@ -94,16 +95,18 @@ export default function GroupBySelect({ groups, columns, onGroupsChanged }: Grou
       })}
 
       {/* Control for adding a new group */}
-      {ungroupedColumns.length > 0 && <GroupColumn
-        key="new-group"
-        columns={ungroupedColumns}
-        groups={groups}
-        currentlySelected={""}
-        onSelect={(newKey) => {
-          onGroupsChanged(groups.concat([newKey]))
-        }}
-        onDelete={() => null}
-      />}
+      {ungroupedColumns.length > 0 && (
+        <GroupColumn
+          key="new-group"
+          columns={ungroupedColumns}
+          groups={groups}
+          currentlySelected={""}
+          onSelect={(newKey) => {
+            onGroupsChanged(groups.concat([newKey]))
+          }}
+          onDelete={() => null}
+        />
+      )}
     </div>
   )
 }

--- a/src/components/GroupBySelect.tsx
+++ b/src/components/GroupBySelect.tsx
@@ -27,17 +27,18 @@ function isGroupable(column: ColumnSpec): boolean {
 function GroupColumn({ columns, currentlySelected, onSelect, onDelete }: GroupColumnProps) {
   const isGrouped = currentlySelected !== "";
   const actionText = isGrouped ? 'Grouped by' : 'Group by';
+  const labelId = `select-column-group-${currentlySelected}`;
   return (
     <FormControl size="small"
     >
       <InputLabel
-        id="select-column-group"
+        id={labelId}
         size="small"
       >
         {actionText}
       </InputLabel>
       <Select
-        labelId="select-column-group"
+        labelId={labelId}
         value={currentlySelected}
         size="small"
         sx={{

--- a/src/components/GroupBySelect.tsx
+++ b/src/components/GroupBySelect.tsx
@@ -1,10 +1,9 @@
-import React from "react"
-
 import { Clear } from "@mui/icons-material"
 import { Divider, FormControl, IconButton, InputLabel, MenuItem, OutlinedInput, Select } from "@mui/material"
 
 import styles from "./GroupBySelect.module.css"
 import { ColumnId, ColumnSpec } from "utils/jobsTableColumns"
+import { Fragment } from "react"
 
 function isGroupable(column: ColumnSpec): boolean {
   return column.groupable
@@ -76,7 +75,7 @@ export default function GroupBySelect({ groups, columns, onGroupsChanged }: Grou
         const alreadyListed = groups.slice(0, i)
         const remainingOptions = groupableColumns.filter((c) => !alreadyListed.includes(c.key))
         return (
-          <React.Fragment key={key}>
+          <Fragment key={key}>
             <GroupColumn
               columns={remainingOptions}
               groups={groups}
@@ -90,7 +89,7 @@ export default function GroupBySelect({ groups, columns, onGroupsChanged }: Grou
               }}
             />
             {remainingOptions.length > 1 && <Divider style={{ width: 10 }} />}
-          </React.Fragment>
+          </Fragment>
         )
       })}
 

--- a/src/components/GroupBySelect.tsx
+++ b/src/components/GroupBySelect.tsx
@@ -6,24 +6,17 @@ import { Divider, FormControl, IconButton, InputLabel, MenuItem, OutlinedInput, 
 import styles from "./GroupBySelect.module.css"
 import { ColumnId, ColumnSpec } from "utils/jobsTableColumns"
 
-type GroupColumnProps = {
+function isGroupable(column: ColumnSpec): boolean {
+  return column.groupable
+}
+
+interface GroupColumnProps {
   columns: ColumnSpec[]
   groups: ColumnId[]
   currentlySelected: ColumnId | ""
   onSelect: (columnKey: ColumnId) => void
   onDelete: () => void
 }
-
-type GroupBySelectProps = {
-  groups: ColumnId[]
-  columns: ColumnSpec[]
-  onGroupsChanged: (newGroups: ColumnId[]) => void
-}
-
-function isGroupable(column: ColumnSpec): boolean {
-  return column.groupable
-}
-
 function GroupColumn({ columns, currentlySelected, onSelect, onDelete }: GroupColumnProps) {
   const isGrouped = currentlySelected !== "";
   const actionText = isGrouped ? 'Grouped by' : 'Group by';
@@ -67,6 +60,11 @@ function GroupColumn({ columns, currentlySelected, onSelect, onDelete }: GroupCo
   )
 }
 
+export interface GroupBySelectProps {
+  groups: ColumnId[]
+  columns: ColumnSpec[]
+  onGroupsChanged: (newGroups: ColumnId[]) => void
+}
 export default function GroupBySelect({ groups, columns, onGroupsChanged }: GroupBySelectProps) {
   const groupableColumns = columns.filter(isGroupable);
   const ungroupedColumns = groupableColumns.filter(c => !groups.includes(c.key))

--- a/src/components/GroupBySelect.tsx
+++ b/src/components/GroupBySelect.tsx
@@ -29,8 +29,7 @@ function GroupColumn({ columns, currentlySelected, onSelect, onDelete }: GroupCo
   const actionText = isGrouped ? 'Grouped by' : 'Group by';
   const labelId = `select-column-group-${currentlySelected}`;
   return (
-    <FormControl size="small"
-    >
+    <FormControl size="small" focused={false}>
       <InputLabel
         id={labelId}
         size="small"

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -1,5 +1,3 @@
-import React from "react"
-
 import { AppBar, Tab, Tabs, Toolbar, Typography } from "@mui/material"
 import Grid from "@mui/material/Grid"
 import { Link, useLocation, useNavigate } from "react-router-dom"

--- a/src/components/jobsTable/JobsTable.test.tsx
+++ b/src/components/jobsTable/JobsTable.test.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import { expect, jest } from "@jest/globals"
-import { render, within, waitFor, waitForElementToBeRemoved } from "@testing-library/react"
+import { render, within, waitFor, waitForElementToBeRemoved, screen } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { Job } from "model"
 import GetJobsService from "services/GetJobsService"
@@ -12,6 +12,7 @@ import { JobsTable } from "./JobsTable"
 import { DEFAULT_COLUMN_SPECS } from "utils/jobsTableColumns"
 
 describe("JobsTable", () => {
+  let numQueues = 2, numJobSets = 3;
   let jobs: Job[], getJobsService: GetJobsService, groupJobsService: GroupJobsService
 
   beforeEach(() => {
@@ -49,7 +50,7 @@ describe("JobsTable", () => {
   })
 
   it("should show jobs by default", async () => {
-    const { findByRole, findAllByRole, getByRole } = renderComponent()
+    const { findByRole, getByRole } = renderComponent()
     await waitForElementToBeRemoved(() => getByRole("progressbar"))
 
     // Check all details for the first job are shown
@@ -61,7 +62,7 @@ describe("JobsTable", () => {
       within(matchingRow).getByText(expectedText!.toString()) // eslint-disable-line @typescript-eslint/no-non-null-assertion
     })
 
-    await assertNumDataRowsShown(jobs.length, findAllByRole)
+    await assertNumDataRowsShown(jobs.length)
   })
 
   it.each([
@@ -71,143 +72,132 @@ describe("JobsTable", () => {
   ])("should allow grouping by %s", async (displayString, groupKey) => {
     const jobObjKey = groupKey as keyof Job
 
-    const numQueues = 2
-    const numJobSets = 3
-    jobs = makeTestJobs(5, 1, numQueues, numJobSets)
-    getJobsService = new FakeGetJobsService(jobs)
-    groupJobsService = new FakeGroupJobsService(jobs)
-
     const numUniqueForJobKey = new Set(jobs.map((j) => j[jobObjKey])).size
 
-    const { findByText, findAllByRole, getByRole } = renderComponent()
+    const { getByRole } = renderComponent()
     await waitForElementToBeRemoved(() => getByRole("progressbar"))
 
-    await groupByHeader(displayString, findByText)
+    await groupByColumn(displayString)
 
     // Check number of rendered rows has changed
-    await assertNumDataRowsShown(numUniqueForJobKey, findAllByRole)
+    await assertNumDataRowsShown(numUniqueForJobKey)
 
     // Expand a row
     const job = jobs[0]
-    await expandRow(job[jobObjKey]!.toString(), getByRole) // eslint-disable-line @typescript-eslint/no-non-null-assertion
+    await expandRow(job[jobObjKey]!.toString()) // eslint-disable-line @typescript-eslint/no-non-null-assertion
 
     // Check the row right number of rows is being shown
     const numShownJobs = jobs.filter((j) => j[jobObjKey] === job[jobObjKey]).length
-    await assertNumDataRowsShown(numUniqueForJobKey + numShownJobs, findAllByRole)
+    await assertNumDataRowsShown(numUniqueForJobKey + numShownJobs)
   })
 
   it("should allow 2 level grouping", async () => {
-    const numQueues = 2
-    const numJobSets = 3
     jobs = makeTestJobs(6, 1, numQueues, numJobSets)
     getJobsService = new FakeGetJobsService(jobs)
     groupJobsService = new FakeGroupJobsService(jobs)
 
-    const { findByText, findAllByRole, getByRole } = renderComponent()
+    const { getByRole } = renderComponent()
     await waitForElementToBeRemoved(() => getByRole("progressbar"))
 
     // Group to both levels
-    await groupByHeader("Queue", findByText)
-    await groupByHeader("Job Set", findByText)
-    await assertNumDataRowsShown(numQueues, findAllByRole)
+    await groupByColumn("Queue")
+    await groupByColumn("Job Set")
+    await assertNumDataRowsShown(numQueues)
 
     const job = jobs[1] // Pick the second job as a bit of variation
 
     // Expand the first level
-    await expandRow(job.queue, getByRole)
-    await assertNumDataRowsShown(numQueues + numJobSets, findAllByRole)
+    await expandRow(job.queue)
+    await assertNumDataRowsShown(numQueues + numJobSets)
 
     // Expand the second level
-    await expandRow(job.jobSet, getByRole)
-    await assertNumDataRowsShown(numQueues + numJobSets + 1, findAllByRole)
+    await expandRow(job.jobSet)
+    await assertNumDataRowsShown(numQueues + numJobSets + 1)
   })
 
   it("should allow 3 level grouping", async () => {
-    const numQueues = 2
-    const numJobSets = 3
     jobs = makeTestJobs(1000, 1, numQueues, numJobSets)
     getJobsService = new FakeGetJobsService(jobs)
     groupJobsService = new FakeGroupJobsService(jobs)
 
     const numStates = new Set(jobs.map((j) => j.state)).size
 
-    const { findByText, findAllByRole, getByRole } = renderComponent()
+    const { getByRole } = renderComponent()
     await waitForElementToBeRemoved(() => getByRole("progressbar"))
 
     // Group to 3 levels
-    await groupByHeader("State", findByText)
-    await groupByHeader("Job Set", findByText)
-    await groupByHeader("Queue", findByText)
-    await assertNumDataRowsShown(numStates, findAllByRole)
+    await groupByColumn("State")
+    await groupByColumn("Job Set")
+    await groupByColumn("Queue")
+    await assertNumDataRowsShown(numStates)
 
     const job = jobs[0]
 
     // Expand the first level
-    await expandRow(job.state, getByRole)
-    await assertNumDataRowsShown(numStates + numJobSets, findAllByRole)
+    await expandRow(job.state)
+    await assertNumDataRowsShown(numStates + numJobSets)
 
     // Expand the second level
-    await expandRow(job.jobSet, getByRole)
-    await assertNumDataRowsShown(numStates + numJobSets + numQueues, findAllByRole)
+    await expandRow(job.jobSet)
+    await assertNumDataRowsShown(numStates + numJobSets + numQueues)
 
     // Expand the third level
-    await expandRow(job.queue, getByRole)
+    await expandRow(job.queue)
     const numJobsExpectedToShow = jobs.filter(
       (j) => j.state === job.state && j.jobSet === job.jobSet && j.queue === job.queue,
     ).length
-    await assertNumDataRowsShown(numStates + numJobSets + numQueues + numJobsExpectedToShow, findAllByRole)
+    await assertNumDataRowsShown(numStates + numJobSets + numQueues + numJobsExpectedToShow)
   })
 
   it("should reset currently-expanded if grouping changes", async () => {
-    const numQueues = 2
-    const numJobSets = 3
     jobs = makeTestJobs(5, 1, numQueues, numJobSets)
     getJobsService = new FakeGetJobsService(jobs)
     groupJobsService = new FakeGroupJobsService(jobs)
 
-    const { findByText, findAllByRole, getByRole, queryAllByRole } = renderComponent()
+    const { getByRole, queryAllByRole } = renderComponent()
     await waitForElementToBeRemoved(() => getByRole("progressbar"))
 
-    await groupByHeader("Queue", findByText)
+    await groupByColumn("Queue")
 
     // Check we're only showing one row for each queue
-    await assertNumDataRowsShown(numQueues, findAllByRole)
+    await assertNumDataRowsShown(numQueues)
 
     // Expand a row
     const job = jobs[0]
-    await expandRow(job.queue, getByRole)
+    await expandRow(job.queue)
 
     // Check the row right number of rows is being shown
     const numShownJobs = jobs.filter((j) => j.queue === job.queue).length
-    await assertNumDataRowsShown(numQueues + numShownJobs, findAllByRole)
+    await assertNumDataRowsShown(numQueues + numShownJobs)
 
     // Assert arrow down icon is shown
     getByRole("button", { name: "Collapse row" })
 
     // Group by another header
-    await groupByHeader("Job Set", findByText)
+    await groupByColumn("Job Set")
 
     // Verify all rows are now collapsed
     waitForElementToBeRemoved(() => queryAllByRole("button", { name: "Expand row" }))
   })
 
-  async function assertNumDataRowsShown(nDataRows: number, findAllByRole: any) {
+  async function assertNumDataRowsShown(nDataRows: number) {
     await waitFor(async () => {
-      const rows = await findAllByRole("row")
+      const rows = await screen.findAllByRole("row")
       expect(rows.length).toBe(nDataRows + 1) // One row per data row, plus the header row
     })
   }
 
-  async function groupByHeader(header: string, findByText: any) {
-    const headerElement = await findByText(header)
-    userEvent.hover(headerElement)
+  async function groupByColumn(columnDisplayName: string) {
+    const groupByDropdownButton = await screen.findByRole("button", {name: "Group by"})
+    userEvent.click(groupByDropdownButton);
 
-    const groupButton = await within(await findByText(header)).findByRole("button")
-    userEvent.click(groupButton)
+    const dropdown = await screen.findByRole("listbox");
+    const colToGroup = await within(dropdown).findByText(columnDisplayName);
+    userEvent.click(colToGroup)
   }
 
-  async function expandRow(buttonText: string, getByRole: any) {
-    const rowToExpand = getByRole("row", {
+  async function expandRow(buttonText: string) {
+    const rowToExpand = await screen.findByRole("row", {
       name: new RegExp(buttonText),
     })
     const expandButton = within(rowToExpand).getByRole("button", { name: "Expand row" })

--- a/src/components/jobsTable/JobsTable.test.tsx
+++ b/src/components/jobsTable/JobsTable.test.tsx
@@ -25,7 +25,6 @@ describe("JobsTable", () => {
       <JobsTable
         getJobsService={getJobsService}
         groupJobsService={groupJobsService}
-        selectedColumns={DEFAULT_COLUMN_SPECS}
       />,
     )
 

--- a/src/components/jobsTable/JobsTable.test.tsx
+++ b/src/components/jobsTable/JobsTable.test.tsx
@@ -12,7 +12,8 @@ import { JobsTable } from "./JobsTable"
 import { DEFAULT_COLUMN_SPECS } from "utils/jobsTableColumns"
 
 describe("JobsTable", () => {
-  let numQueues = 2, numJobSets = 3;
+  const numQueues = 2,
+    numJobSets = 3
   let jobs: Job[], getJobsService: GetJobsService, groupJobsService: GroupJobsService
 
   beforeEach(() => {
@@ -22,12 +23,7 @@ describe("JobsTable", () => {
   })
 
   const renderComponent = () =>
-    render(
-      <JobsTable
-        getJobsService={getJobsService}
-        groupJobsService={groupJobsService}
-      />,
-    )
+    render(<JobsTable getJobsService={getJobsService} groupJobsService={groupJobsService} />)
 
   it("should render a spinner while loading initially", async () => {
     getJobsService.getJobs = jest.fn(() => new Promise(() => undefined))
@@ -188,11 +184,11 @@ describe("JobsTable", () => {
   }
 
   async function groupByColumn(columnDisplayName: string) {
-    const groupByDropdownButton = await screen.findByRole("button", {name: "Group by"})
-    userEvent.click(groupByDropdownButton);
+    const groupByDropdownButton = await screen.findByRole("button", { name: "Group by" })
+    userEvent.click(groupByDropdownButton)
 
-    const dropdown = await screen.findByRole("listbox");
-    const colToGroup = await within(dropdown).findByText(columnDisplayName);
+    const dropdown = await screen.findByRole("listbox")
+    const colToGroup = await within(dropdown).findByText(columnDisplayName)
     userEvent.click(colToGroup)
   }
 

--- a/src/components/jobsTable/JobsTable.test.tsx
+++ b/src/components/jobsTable/JobsTable.test.tsx
@@ -1,4 +1,3 @@
-import React from "react"
 import { expect, jest } from "@jest/globals"
 import { render, within, waitFor, waitForElementToBeRemoved, screen } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"

--- a/src/components/jobsTable/JobsTable.tsx
+++ b/src/components/jobsTable/JobsTable.tsx
@@ -69,6 +69,7 @@ export const JobsTable = ({ getJobsService, groupJobsService }: JobsPageProps) =
   )
 
   const [grouping, setGrouping] = useState<ColumnId[]>(DEFAULT_GROUPING)
+  const prevGrouping = usePrevious(grouping);
   const [expanded, setExpanded] = useState<ExpandedState>({})
   const prevExpanded = usePrevious(expanded)
   const { newlyExpanded, newlyUnexpanded } = useMemo(() => {
@@ -99,7 +100,7 @@ export const JobsTable = ({ getJobsService, groupJobsService }: JobsPageProps) =
     async function fetchData() {
       // TODO: Support filtering
 
-      if (newlyUnexpanded.length > 0) {
+      if (grouping === prevGrouping && newlyUnexpanded.length > 0) {
         console.log("Not fetching new data since we're unexpanding")
         return
       }
@@ -147,7 +148,7 @@ export const JobsTable = ({ getJobsService, groupJobsService }: JobsPageProps) =
 
   const onGroupingChange = useCallback((newState: ColumnId[]) => {
     setExpanded({}) // Reset currently-expanded when grouping changes
-    setGrouping(newState)
+    setGrouping([...newState])
   }, [setExpanded, setGrouping]);
 
   const table = useReactTable({

--- a/src/components/jobsTable/JobsTable.tsx
+++ b/src/components/jobsTable/JobsTable.tsx
@@ -17,7 +17,6 @@ import {
   getFilteredRowModel,
   getGroupedRowModel,
   getPaginationRowModel,
-  GroupingState,
   PaginationState,
   Row,
   useReactTable,
@@ -27,7 +26,7 @@ import GetJobsService from "services/GetJobsService"
 import GroupJobsService from "services/GroupJobsService"
 import { usePrevious } from "hooks/usePrevious"
 import { fromRowId, mergeSubRows, RowId } from "utils/reactTableUtils"
-import { JobTableRow, JobRow, isJobGroupRow } from "models/jobsTableModels"
+import { JobTableRow, isJobGroupRow } from "models/jobsTableModels"
 import {
   convertExpandedRowFieldsToFilters,
   fetchJobGroups,
@@ -47,12 +46,12 @@ export const JobsTable = ({ getJobsService, groupJobsService }: JobsPageProps) =
   const [isLoading, setIsLoading] = useState(true)
   const [data, setData] = useState<JobTableRow[]>([])
   const [totalRowCount, setTotalRowCount] = useState(0)
-  const [allColumns, setAllColumns] = useState(DEFAULT_COLUMN_SPECS);
+  const [allColumns, setAllColumns] = useState(DEFAULT_COLUMN_SPECS)
 
   const selectedColumnDefs = useMemo<ColumnDef<JobTableRow>[]>(
     () =>
       allColumns
-        .filter(c => c.selected)
+        .filter((c) => c.selected)
         .map(
           (c): ColumnDef<JobTableRow> => ({
             id: c.key,
@@ -69,7 +68,7 @@ export const JobsTable = ({ getJobsService, groupJobsService }: JobsPageProps) =
   )
 
   const [grouping, setGrouping] = useState<ColumnId[]>(DEFAULT_GROUPING)
-  const prevGrouping = usePrevious(grouping);
+  const prevGrouping = usePrevious(grouping)
   const [expanded, setExpanded] = useState<ExpandedState>({})
   const prevExpanded = usePrevious(expanded)
   const { newlyExpanded, newlyUnexpanded } = useMemo(() => {
@@ -146,17 +145,22 @@ export const JobsTable = ({ getJobsService, groupJobsService }: JobsPageProps) =
     fetchData().catch(console.error)
   }, [pagination, grouping, expanded])
 
-  const onGroupingChange = useCallback((newState: ColumnId[]) => {
-    setExpanded({}) // Reset currently-expanded when grouping changes
+  const onGroupingChange = useCallback(
+    (newState: ColumnId[]) => {
+      setExpanded({}) // Reset currently-expanded when grouping changes
 
-    // Check all grouping columns are displayed
-    setAllColumns(allColumns.map(col => ({
-      ...col,
-      selected: newState.includes(col.key) ? true : col.selected
-    })))
+      // Check all grouping columns are displayed
+      setAllColumns(
+        allColumns.map((col) => ({
+          ...col,
+          selected: newState.includes(col.key) ? true : col.selected,
+        })),
+      )
 
-    setGrouping([...newState])
-  }, [setExpanded, setAllColumns, allColumns, setGrouping]);
+      setGrouping([...newState])
+    },
+    [setExpanded, setAllColumns, allColumns, setGrouping],
+  )
 
   const table = useReactTable({
     data: data ?? [],
@@ -191,7 +195,12 @@ export const JobsTable = ({ getJobsService, groupJobsService }: JobsPageProps) =
   const rowsToRender = table.getRowModel().rows
   return (
     <>
-      <JobsTableActionBar allColumns={allColumns} groupedColumns={grouping} onColumnsChanged={setAllColumns} onGroupsChanged={onGroupingChange} />
+      <JobsTableActionBar
+        allColumns={allColumns}
+        groupedColumns={grouping}
+        onColumnsChanged={setAllColumns}
+        onGroupsChanged={onGroupingChange}
+      />
       <TableContainer component={Paper}>
         <Table>
           <TableHead>

--- a/src/components/jobsTable/JobsTable.tsx
+++ b/src/components/jobsTable/JobsTable.tsx
@@ -35,18 +35,19 @@ import {
   groupsToRows,
   jobsToRows,
 } from "utils/jobsTableUtils"
-import { ColumnId, ColumnSpec } from "utils/jobsTableColumns"
+import { ColumnId, ColumnSpec, DEFAULT_COLUMN_SPECS } from "utils/jobsTableColumns"
 import { BodyCell, HeaderCell } from "./JobsTableCell"
+import { JobsTableActionBar } from "./JobsTableActionBar"
 
 type JobsPageProps = {
   getJobsService: GetJobsService
   groupJobsService: GroupJobsService
-  selectedColumns: ColumnSpec[]
 }
-export const JobsTable = ({ getJobsService, groupJobsService, selectedColumns }: JobsPageProps) => {
+export const JobsTable = ({ getJobsService, groupJobsService }: JobsPageProps) => {
   const [isLoading, setIsLoading] = useState(true)
   const [data, setData] = useState<JobTableRow[]>([])
   const [totalRowCount, setTotalRowCount] = useState(0)
+  const [selectedColumns, setSelectedColumns] = useState(DEFAULT_COLUMN_SPECS);
 
   const columns = useMemo<ColumnDef<JobRow>[]>(
     () =>
@@ -178,6 +179,7 @@ export const JobsTable = ({ getJobsService, groupJobsService, selectedColumns }:
   const rowsToRender = table.getRowModel().rows
   return (
     <>
+    <JobsTableActionBar columns={selectedColumns} onColumnsChanged={setSelectedColumns} />
       <TableContainer component={Paper}>
         <Table>
           <TableHead>

--- a/src/components/jobsTable/JobsTable.tsx
+++ b/src/components/jobsTable/JobsTable.tsx
@@ -21,7 +21,7 @@ import {
   Row,
   useReactTable,
 } from "@tanstack/react-table"
-import React, { useCallback, useMemo, useState } from "react"
+import { memo, useCallback, useEffect, useMemo, useState } from "react"
 import GetJobsService from "services/GetJobsService"
 import GroupJobsService from "services/GroupJobsService"
 import { usePrevious } from "hooks/usePrevious"
@@ -93,9 +93,9 @@ export const JobsTable = ({ getJobsService, groupJobsService }: JobsPageProps) =
     [pageIndex, pageSize],
   )
 
-  const [hoveredHeaderColumn, setHoveredHeaderColumn] = React.useState<ColumnId | undefined>(undefined)
+  const [hoveredHeaderColumn, setHoveredHeaderColumn] = useState<ColumnId | undefined>(undefined)
 
-  React.useEffect(() => {
+  useEffect(() => {
     async function fetchData() {
       // TODO: Support filtering
 
@@ -240,7 +240,7 @@ interface JobsTableBodyProps {
   columns: ColumnDef<JobTableRow>[]
   rowsToRender: Row<JobTableRow>[]
 }
-const JobsTableBody = React.memo(({ dataIsLoading, columns, rowsToRender }: JobsTableBodyProps) => {
+const JobsTableBody = memo(({ dataIsLoading, columns, rowsToRender }: JobsTableBodyProps) => {
   // This memoized component saves re-rendering if the data to display hasn't changed
   const canDisplay = !dataIsLoading && rowsToRender.length > 0
   return (

--- a/src/components/jobsTable/JobsTable.tsx
+++ b/src/components/jobsTable/JobsTable.tsx
@@ -148,8 +148,15 @@ export const JobsTable = ({ getJobsService, groupJobsService }: JobsPageProps) =
 
   const onGroupingChange = useCallback((newState: ColumnId[]) => {
     setExpanded({}) // Reset currently-expanded when grouping changes
+
+    // Check all grouping columns are displayed
+    setAllColumns(allColumns.map(col => ({
+      ...col,
+      selected: newState.includes(col.key) ? true : col.selected
+    })))
+
     setGrouping([...newState])
-  }, [setExpanded, setGrouping]);
+  }, [setExpanded, setAllColumns, allColumns, setGrouping]);
 
   const table = useReactTable({
     data: data ?? [],

--- a/src/components/jobsTable/JobsTableActionBar.module.css
+++ b/src/components/jobsTable/JobsTableActionBar.module.css
@@ -1,0 +1,29 @@
+.actionBar {
+    width: 100%;
+    display: flex;
+    flex-direction: row;
+    margin-bottom: 0.5em;
+}
+
+.actionGroup {
+    display: flex;
+    flex-direction: row;
+    column-gap: 0.5em;
+}
+.actionBar .actionGroup:last-child {
+    margin-left: auto;
+}
+
+.actions {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+}
+
+.actionItem {
+    margin-left: 0.5em;
+    margin-right: 0.5em;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}

--- a/src/components/jobsTable/JobsTableActionBar.module.css
+++ b/src/components/jobsTable/JobsTableActionBar.module.css
@@ -12,6 +12,8 @@
     flex-direction: row;
     column-gap: 0.5em;
 }
+
+/* Pull the last action group to the right-hand side */
 .actionBar .actionGroup:last-child {
     margin-left: auto;
 }

--- a/src/components/jobsTable/JobsTableActionBar.module.css
+++ b/src/components/jobsTable/JobsTableActionBar.module.css
@@ -15,17 +15,3 @@
 .actionBar .actionGroup:last-child {
     margin-left: auto;
 }
-
-.actions {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-}
-
-.actionItem {
-    margin-left: 0.5em;
-    margin-right: 0.5em;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-}

--- a/src/components/jobsTable/JobsTableActionBar.module.css
+++ b/src/components/jobsTable/JobsTableActionBar.module.css
@@ -2,6 +2,8 @@
     width: 100%;
     display: flex;
     flex-direction: row;
+    flex-wrap: wrap;
+    gap: 0.5em;
     margin-bottom: 0.5em;
 }
 

--- a/src/components/jobsTable/JobsTableActionBar.tsx
+++ b/src/components/jobsTable/JobsTableActionBar.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { Typography, Divider, Button } from "@mui/material"
+import ColumnSelect from "components/ColumnSelect"
+import { useState } from "react"
+import { ColumnSpec, DEFAULT_COLUMN_SPECS, columnSpecFor, ColumnId } from "utils/jobsTableColumns"
+import styles from './JobsTableActionBar.module.css';
+
+const HEADING_SECTION_HEIGHT = 48
+
+export interface JobsTableActionBarProps {
+    columns: ColumnSpec[];
+    onColumnsChanged: (newColumns: ColumnSpec[]) => void;
+}
+export const JobsTableActionBar = ({ columns, onColumnsChanged }: JobsTableActionBarProps) => {
+    // const [columns, setColumns] = useState<ColumnSpec[]>(DEFAULT_COLUMN_SPECS)
+
+    function toggleColumn(key: string) {
+        const newColumns = columns.map((col) => col)
+        for (let i = 0; i < newColumns.length; i++) {
+            if (newColumns[i].key === key) {
+                newColumns[i].selected = !newColumns[i].selected
+            }
+        }
+        onColumnsChanged(newColumns)
+    }
+
+    function addAnnotationColumn(name: string) {
+        const newColumns = columns.map((col) => col)
+        newColumns.push({
+            ...columnSpecFor(name as ColumnId),
+            isAnnotation: true,
+        })
+        onColumnsChanged(newColumns)
+    }
+
+    function removeAnnotationColumn(key: string) {
+        const filtered = columns.filter((col) => col.key !== key)
+        onColumnsChanged(filtered)
+    }
+
+    function editAnnotationColumn(key: string, name: string) {
+        const newColumns = columns.map((col) => col)
+        for (let i = 0; i < newColumns.length; i++) {
+            if (newColumns[i].key === key) {
+                newColumns[i].name = name
+            }
+        }
+        onColumnsChanged(newColumns)
+    }
+
+    return (
+        <div className={styles.actionBar}>
+            <Typography className={styles.actionGroup}
+                variant="h4"
+            >
+                Jobs
+            </Typography>
+
+            <div className={styles.actionGroup}>
+                <ColumnSelect
+                    columns={columns}
+                    onAddAnnotation={addAnnotationColumn}
+                    onToggleColumn={toggleColumn}
+                    onEditAnnotation={editAnnotationColumn}
+                    onRemoveAnnotation={removeAnnotationColumn}
+                />
+                <Divider
+                    orientation="vertical"
+                />
+                <Button
+                    variant="contained"
+                >
+                    Cancel
+                </Button>
+                <Button
+                    variant="contained"
+                >
+                    Reprioritize
+                </Button>
+            </div>
+        </div>
+    )
+}

--- a/src/components/jobsTable/JobsTableActionBar.tsx
+++ b/src/components/jobsTable/JobsTableActionBar.tsx
@@ -12,9 +12,9 @@ export interface JobsTableActionBarProps {
     onColumnsChanged: (newColumns: ColumnSpec[]) => void;
     onGroupsChanged: (newGroups: ColumnId[]) => void;
 }
-export const JobsTableActionBar = ({ allColumns: columns, groupedColumns: groups, onColumnsChanged, onGroupsChanged }: JobsTableActionBarProps) => {
+export const JobsTableActionBar = ({ allColumns, groupedColumns, onColumnsChanged, onGroupsChanged }: JobsTableActionBarProps) => {
     function toggleColumn(key: string) {
-        const newColumns = columns.map((col) => col)
+        const newColumns = allColumns.map((col) => col)
         for (let i = 0; i < newColumns.length; i++) {
             if (newColumns[i].key === key) {
                 newColumns[i].selected = !newColumns[i].selected
@@ -24,7 +24,7 @@ export const JobsTableActionBar = ({ allColumns: columns, groupedColumns: groups
     }
 
     function addAnnotationColumn(name: string) {
-        const newColumns = columns.map((col) => col)
+        const newColumns = allColumns.map((col) => col)
         newColumns.push({
             ...columnSpecFor(name as ColumnId),
             isAnnotation: true,
@@ -33,12 +33,12 @@ export const JobsTableActionBar = ({ allColumns: columns, groupedColumns: groups
     }
 
     function removeAnnotationColumn(key: string) {
-        const filtered = columns.filter((col) => col.key !== key)
+        const filtered = allColumns.filter((col) => col.key !== key)
         onColumnsChanged(filtered)
     }
 
     function editAnnotationColumn(key: string, name: string) {
-        const newColumns = columns.map((col) => col)
+        const newColumns = allColumns.map((col) => col)
         for (let i = 0; i < newColumns.length; i++) {
             if (newColumns[i].key === key) {
                 newColumns[i].name = name
@@ -50,14 +50,15 @@ export const JobsTableActionBar = ({ allColumns: columns, groupedColumns: groups
     return (
         <div className={styles.actionBar}>
             <GroupBySelect
-                columns={columns}
-                groups={groups}
+                columns={allColumns}
+                groups={groupedColumns}
                 onGroupsChanged={onGroupsChanged}
             />
 
             <div className={styles.actionGroup}>
                 <ColumnSelect
-                    allColumns={columns}
+                    allColumns={allColumns}
+                    groupedColumns={groupedColumns}
                     onAddAnnotation={addAnnotationColumn}
                     onToggleColumn={toggleColumn}
                     onEditAnnotation={editAnnotationColumn}

--- a/src/components/jobsTable/JobsTableActionBar.tsx
+++ b/src/components/jobsTable/JobsTableActionBar.tsx
@@ -1,83 +1,72 @@
-import React from 'react';
-import { Typography, Divider, Button } from "@mui/material"
+import { Divider, Button } from "@mui/material"
 import ColumnSelect from "components/ColumnSelect"
-import { useState } from "react"
-import { ColumnSpec, DEFAULT_COLUMN_SPECS, columnSpecFor, ColumnId } from "utils/jobsTableColumns"
-import styles from './JobsTableActionBar.module.css';
-import GroupBySelect from 'components/GroupBySelect';
+import { ColumnSpec, columnSpecFor, ColumnId } from "utils/jobsTableColumns"
+import styles from "./JobsTableActionBar.module.css"
+import GroupBySelect from "components/GroupBySelect"
 
 export interface JobsTableActionBarProps {
-    allColumns: ColumnSpec[];
-    groupedColumns: ColumnId[];
-    onColumnsChanged: (newColumns: ColumnSpec[]) => void;
-    onGroupsChanged: (newGroups: ColumnId[]) => void;
+  allColumns: ColumnSpec[]
+  groupedColumns: ColumnId[]
+  onColumnsChanged: (newColumns: ColumnSpec[]) => void
+  onGroupsChanged: (newGroups: ColumnId[]) => void
 }
-export const JobsTableActionBar = ({ allColumns, groupedColumns, onColumnsChanged, onGroupsChanged }: JobsTableActionBarProps) => {
-    function toggleColumn(key: string) {
-        const newColumns = allColumns.map((col) => col)
-        for (let i = 0; i < newColumns.length; i++) {
-            if (newColumns[i].key === key) {
-                newColumns[i].selected = !newColumns[i].selected
-            }
-        }
-        onColumnsChanged(newColumns)
+export const JobsTableActionBar = ({
+  allColumns,
+  groupedColumns,
+  onColumnsChanged,
+  onGroupsChanged,
+}: JobsTableActionBarProps) => {
+  function toggleColumn(key: string) {
+    const newColumns = allColumns.map((col) => col)
+    for (let i = 0; i < newColumns.length; i++) {
+      if (newColumns[i].key === key) {
+        newColumns[i].selected = !newColumns[i].selected
+      }
     }
+    onColumnsChanged(newColumns)
+  }
 
-    function addAnnotationColumn(name: string) {
-        const newColumns = allColumns.map((col) => col)
-        newColumns.push({
-            ...columnSpecFor(name as ColumnId),
-            isAnnotation: true,
-        })
-        onColumnsChanged(newColumns)
+  function addAnnotationColumn(name: string) {
+    const newColumns = allColumns.map((col) => col)
+    newColumns.push({
+      ...columnSpecFor(name as ColumnId),
+      isAnnotation: true,
+    })
+    onColumnsChanged(newColumns)
+  }
+
+  function removeAnnotationColumn(key: string) {
+    const filtered = allColumns.filter((col) => col.key !== key)
+    onColumnsChanged(filtered)
+  }
+
+  function editAnnotationColumn(key: string, name: string) {
+    const newColumns = allColumns.map((col) => col)
+    for (let i = 0; i < newColumns.length; i++) {
+      if (newColumns[i].key === key) {
+        newColumns[i].name = name
+      }
     }
+    onColumnsChanged(newColumns)
+  }
 
-    function removeAnnotationColumn(key: string) {
-        const filtered = allColumns.filter((col) => col.key !== key)
-        onColumnsChanged(filtered)
-    }
+  return (
+    <div className={styles.actionBar}>
+      <GroupBySelect columns={allColumns} groups={groupedColumns} onGroupsChanged={onGroupsChanged} />
 
-    function editAnnotationColumn(key: string, name: string) {
-        const newColumns = allColumns.map((col) => col)
-        for (let i = 0; i < newColumns.length; i++) {
-            if (newColumns[i].key === key) {
-                newColumns[i].name = name
-            }
-        }
-        onColumnsChanged(newColumns)
-    }
-
-    return (
-        <div className={styles.actionBar}>
-            <GroupBySelect
-                columns={allColumns}
-                groups={groupedColumns}
-                onGroupsChanged={onGroupsChanged}
-            />
-
-            <div className={styles.actionGroup}>
-                <ColumnSelect
-                    allColumns={allColumns}
-                    groupedColumns={groupedColumns}
-                    onAddAnnotation={addAnnotationColumn}
-                    onToggleColumn={toggleColumn}
-                    onEditAnnotation={editAnnotationColumn}
-                    onRemoveAnnotation={removeAnnotationColumn}
-                />
-                <Divider
-                    orientation="vertical"
-                />
-                <Button
-                    variant="contained"
-                >
-                    Cancel
-                </Button>
-                <Button
-                    variant="contained"
-                >
-                    Reprioritize
-                </Button>
-            </div>
-        </div>
-    )
+      <div className={styles.actionGroup}>
+        <ColumnSelect
+          allColumns={allColumns}
+          groupedColumns={groupedColumns}
+          onAddAnnotation={addAnnotationColumn}
+          onToggleColumn={toggleColumn}
+          onEditAnnotation={editAnnotationColumn}
+          onRemoveAnnotation={removeAnnotationColumn}
+        />
+        <Divider orientation="vertical" />
+        <Button variant="contained">Cancel</Button>
+        <Button variant="contained">Reprioritize</Button>
+      </div>
+    </div>
+  )
 }

--- a/src/components/jobsTable/JobsTableActionBar.tsx
+++ b/src/components/jobsTable/JobsTableActionBar.tsx
@@ -6,17 +6,13 @@ import { ColumnSpec, DEFAULT_COLUMN_SPECS, columnSpecFor, ColumnId } from "utils
 import styles from './JobsTableActionBar.module.css';
 import GroupBySelect from 'components/GroupBySelect';
 
-const HEADING_SECTION_HEIGHT = 48
-
 export interface JobsTableActionBarProps {
-    columns: ColumnSpec[];
-    groups: ColumnId[];
+    allColumns: ColumnSpec[];
+    groupedColumns: ColumnId[];
     onColumnsChanged: (newColumns: ColumnSpec[]) => void;
     onGroupsChanged: (newGroups: ColumnId[]) => void;
 }
-export const JobsTableActionBar = ({ columns, groups, onColumnsChanged, onGroupsChanged }: JobsTableActionBarProps) => {
-    // const [columns, setColumns] = useState<ColumnSpec[]>(DEFAULT_COLUMN_SPECS)
-
+export const JobsTableActionBar = ({ allColumns: columns, groupedColumns: groups, onColumnsChanged, onGroupsChanged }: JobsTableActionBarProps) => {
     function toggleColumn(key: string) {
         const newColumns = columns.map((col) => col)
         for (let i = 0; i < newColumns.length; i++) {
@@ -61,7 +57,7 @@ export const JobsTableActionBar = ({ columns, groups, onColumnsChanged, onGroups
 
             <div className={styles.actionGroup}>
                 <ColumnSelect
-                    columns={columns}
+                    allColumns={columns}
                     onAddAnnotation={addAnnotationColumn}
                     onToggleColumn={toggleColumn}
                     onEditAnnotation={editAnnotationColumn}

--- a/src/components/jobsTable/JobsTableActionBar.tsx
+++ b/src/components/jobsTable/JobsTableActionBar.tsx
@@ -17,36 +17,33 @@ export const JobsTableActionBar = ({
   onGroupsChanged,
 }: JobsTableActionBarProps) => {
   function toggleColumn(key: string) {
-    const newColumns = allColumns.map((col) => col)
-    for (let i = 0; i < newColumns.length; i++) {
-      if (newColumns[i].key === key) {
-        newColumns[i].selected = !newColumns[i].selected
-      }
-    }
+    const newColumns = allColumns.map((col) => ({
+      ...col,
+      selected: col.key === key ? !col.selected : col.selected,
+    }))
     onColumnsChanged(newColumns)
   }
 
   function addAnnotationColumn(name: string) {
-    const newColumns = allColumns.map((col) => col)
-    newColumns.push({
-      ...columnSpecFor(name as ColumnId),
-      isAnnotation: true,
-    })
+    const newColumns = allColumns.concat([
+      {
+        ...columnSpecFor(name as ColumnId),
+        isAnnotation: true,
+      },
+    ])
     onColumnsChanged(newColumns)
   }
 
   function removeAnnotationColumn(key: string) {
-    const filtered = allColumns.filter((col) => col.key !== key)
+    const filtered = allColumns.filter((col) => !col.isAnnotation || col.key !== key)
     onColumnsChanged(filtered)
   }
 
-  function editAnnotationColumn(key: string, name: string) {
-    const newColumns = allColumns.map((col) => col)
-    for (let i = 0; i < newColumns.length; i++) {
-      if (newColumns[i].key === key) {
-        newColumns[i].name = name
-      }
-    }
+  function editAnnotationColumn(key: string, newName: string) {
+    const newColumns = allColumns.map((col) => ({
+      ...col,
+      name: col.key === key ? newName : col.name,
+    }))
     onColumnsChanged(newColumns)
   }
 

--- a/src/components/jobsTable/JobsTableActionBar.tsx
+++ b/src/components/jobsTable/JobsTableActionBar.tsx
@@ -52,7 +52,9 @@ export const JobsTableActionBar = ({
 
   return (
     <div className={styles.actionBar}>
-      <GroupBySelect columns={allColumns} groups={groupedColumns} onGroupsChanged={onGroupsChanged} />
+      <div className={styles.actionGroup}>
+        <GroupBySelect columns={allColumns} groups={groupedColumns} onGroupsChanged={onGroupsChanged} />
+      </div>
 
       <div className={styles.actionGroup}>
         <ColumnSelect

--- a/src/components/jobsTable/JobsTableActionBar.tsx
+++ b/src/components/jobsTable/JobsTableActionBar.tsx
@@ -4,14 +4,17 @@ import ColumnSelect from "components/ColumnSelect"
 import { useState } from "react"
 import { ColumnSpec, DEFAULT_COLUMN_SPECS, columnSpecFor, ColumnId } from "utils/jobsTableColumns"
 import styles from './JobsTableActionBar.module.css';
+import GroupBySelect from 'components/GroupBySelect';
 
 const HEADING_SECTION_HEIGHT = 48
 
 export interface JobsTableActionBarProps {
     columns: ColumnSpec[];
+    groups: ColumnId[];
     onColumnsChanged: (newColumns: ColumnSpec[]) => void;
+    onGroupsChanged: (newGroups: ColumnId[]) => void;
 }
-export const JobsTableActionBar = ({ columns, onColumnsChanged }: JobsTableActionBarProps) => {
+export const JobsTableActionBar = ({ columns, groups, onColumnsChanged, onGroupsChanged }: JobsTableActionBarProps) => {
     // const [columns, setColumns] = useState<ColumnSpec[]>(DEFAULT_COLUMN_SPECS)
 
     function toggleColumn(key: string) {
@@ -50,11 +53,11 @@ export const JobsTableActionBar = ({ columns, onColumnsChanged }: JobsTableActio
 
     return (
         <div className={styles.actionBar}>
-            <Typography className={styles.actionGroup}
-                variant="h4"
-            >
-                Jobs
-            </Typography>
+            <GroupBySelect
+                columns={columns}
+                groups={groups}
+                onGroupsChanged={onGroupsChanged}
+            />
 
             <div className={styles.actionGroup}>
                 <ColumnSelect

--- a/src/components/jobsTable/JobsTableCell.tsx
+++ b/src/components/jobsTable/JobsTableCell.tsx
@@ -25,9 +25,8 @@ export const HeaderCell = ({ header, hoveredColumn, onHoverChange }: HeaderCellP
   const isRightAligned = shouldRightAlign(colSpec)
 
   // To be used for sorting icons in future
-  // @eslint-disable-next-line
-  const isHovered = id === hoveredColumn
-  
+  const _isHovered = id === hoveredColumn
+
   return (
     <TableCell
       key={id}
@@ -75,7 +74,7 @@ export const BodyCell = ({ cell, rowIsGroup, rowIsExpanded, onExpandedChange, su
       {rowIsGroup && cell.column.getIsGrouped() && cellHasValue ? (
         // If it's a grouped cell, add an expander and row count
         <>
-          <IconButton size="small" sx={{padding: 0}} edge="start" onClick={() => onExpandedChange()}>
+          <IconButton size="small" sx={{ padding: 0 }} edge="start" onClick={() => onExpandedChange()}>
             {rowIsExpanded ? (
               <KeyboardArrowDown fontSize="small" aria-label="Collapse row" aria-hidden="false" />
             ) : (

--- a/src/components/jobsTable/JobsTableCell.tsx
+++ b/src/components/jobsTable/JobsTableCell.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { GroupRemoveOutlined, GroupAddOutlined, KeyboardArrowRight, KeyboardArrowDown } from "@mui/icons-material"
+import { KeyboardArrowRight, KeyboardArrowDown } from "@mui/icons-material"
 import { TableCell, IconButton } from "@mui/material"
 import { Cell, flexRender, Header } from "@tanstack/react-table"
 import { JobRow } from "models/jobsTableModels"
@@ -22,8 +22,12 @@ export interface HeaderCellProps {
 export const HeaderCell = ({ header, hoveredColumn, onHoverChange }: HeaderCellProps) => {
   const id = header.id as ColumnId
   const colSpec = columnSpecFor(id)
-  const isHovered = id === hoveredColumn
   const isRightAligned = shouldRightAlign(colSpec)
+
+  // To be used for sorting icons in future
+  // @eslint-disable-next-line
+  const isHovered = id === hoveredColumn
+  
   return (
     <TableCell
       key={id}
@@ -41,16 +45,6 @@ export const HeaderCell = ({ header, hoveredColumn, onHoverChange }: HeaderCellP
         <>
           {flexRender(header.column.columnDef.header, header.getContext())}
           {header.column.getIsGrouped() && <> (# Jobs)</>}
-          {header.column.getCanGroup() && isHovered ? (
-            // If the header can be grouped, let's add a toggle
-            <IconButton size="small" onClick={header.column.getToggleGroupingHandler()}>
-              {header.column.getIsGrouped() ? (
-                <GroupRemoveOutlined fontSize="small" aria-hidden="false" aria-label="Group By" />
-              ) : (
-                <GroupAddOutlined fontSize="small" aria-hidden="false" aria-label="Ungroup By" />
-              )}
-            </IconButton>
-          ) : null}{" "}
         </>
       )}
     </TableCell>
@@ -81,7 +75,7 @@ export const BodyCell = ({ cell, rowIsGroup, rowIsExpanded, onExpandedChange, su
       {rowIsGroup && cell.column.getIsGrouped() && cellHasValue ? (
         // If it's a grouped cell, add an expander and row count
         <>
-          <IconButton size="small" edge="start" onClick={() => onExpandedChange()}>
+          <IconButton size="small" sx={{padding: 0}} edge="start" onClick={() => onExpandedChange()}>
             {rowIsExpanded ? (
               <KeyboardArrowDown fontSize="small" aria-label="Collapse row" aria-hidden="false" />
             ) : (

--- a/src/components/jobsTable/JobsTableCell.tsx
+++ b/src/components/jobsTable/JobsTableCell.tsx
@@ -1,4 +1,3 @@
-import React from "react"
 import { KeyboardArrowRight, KeyboardArrowDown } from "@mui/icons-material"
 import { TableCell, IconButton } from "@mui/material"
 import { Cell, flexRender, Header } from "@tanstack/react-table"

--- a/src/pages/App.test.tsx
+++ b/src/pages/App.test.tsx
@@ -1,5 +1,3 @@
-import React from "react"
-
 import { render, screen } from "@testing-library/react"
 
 import App from "./App"

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef, useState } from "react"
+import { useEffect, useMemo, useRef, useState } from "react"
 
 import { createTheme, ThemeProvider } from "@mui/material"
 import { grey, red } from "@mui/material/colors"

--- a/src/pages/JobsPage.module.css
+++ b/src/pages/JobsPage.module.css
@@ -5,21 +5,6 @@
     align-items: center;
 }
 
-.actions {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-}
-
-.actionItem {
-    margin-left: 0.5em;
-    margin-right: 0.5em;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-}
-
 .jobsTable {
-    margin-left: 0.5em;
-    margin-right: 0.5em;
+    margin: 0.5em;
 }

--- a/src/pages/JobsPage.module.css
+++ b/src/pages/JobsPage.module.css
@@ -1,10 +1,3 @@
-.header {
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
-    align-items: center;
-}
-
 .jobsTable {
     margin: 0.5em;
 }

--- a/src/pages/JobsPage.tsx
+++ b/src/pages/JobsPage.tsx
@@ -1,15 +1,7 @@
-import React, { useState } from "react"
-
-import { Button, Divider, Typography } from "@mui/material"
-
-import ColumnSelect from "components/ColumnSelect"
 import GetJobsService from "services/GetJobsService"
 import GroupJobsService from "services/GroupJobsService"
 import styles from "./JobsPage.module.css"
 import { JobsTable } from "components/jobsTable/JobsTable"
-import { ColumnId, ColumnSpec, columnSpecFor, DEFAULT_COLUMN_SPECS } from "utils/jobsTableColumns"
-import { JobsTableActionBar } from "components/jobsTable/JobsTableActionBar"
-
 
 type JobsPageProps = {
   width: number
@@ -21,10 +13,7 @@ type JobsPageProps = {
 export default function JobsPage(props: JobsPageProps) {
   return (
     <div className={styles.jobsTable}>
-      <JobsTable
-        getJobsService={props.getJobsService}
-        groupJobsService={props.groupJobsService}
-      />
+      <JobsTable getJobsService={props.getJobsService} groupJobsService={props.groupJobsService} />
     </div>
   )
 }

--- a/src/pages/JobsPage.tsx
+++ b/src/pages/JobsPage.tsx
@@ -8,8 +8,8 @@ import GroupJobsService from "services/GroupJobsService"
 import styles from "./JobsPage.module.css"
 import { JobsTable } from "components/jobsTable/JobsTable"
 import { ColumnId, ColumnSpec, columnSpecFor, DEFAULT_COLUMN_SPECS } from "utils/jobsTableColumns"
+import { JobsTableActionBar } from "components/jobsTable/JobsTableActionBar"
 
-const HEADING_SECTION_HEIGHT = 48
 
 type JobsPageProps = {
   width: number
@@ -19,115 +19,12 @@ type JobsPageProps = {
 }
 
 export default function JobsPage(props: JobsPageProps) {
-  const [columns, setColumns] = useState<ColumnSpec[]>(DEFAULT_COLUMN_SPECS)
-
-  function toggleColumn(key: string) {
-    const newColumns = columns.map((col) => col)
-    for (let i = 0; i < newColumns.length; i++) {
-      if (newColumns[i].key === key) {
-        newColumns[i].selected = !newColumns[i].selected
-      }
-    }
-    setColumns(newColumns)
-  }
-
-  function addAnnotationColumn(name: string) {
-    const newColumns = columns.map((col) => col)
-    newColumns.push({
-      ...columnSpecFor(name as ColumnId),
-      isAnnotation: true,
-    })
-    setColumns(newColumns)
-  }
-
-  function removeAnnotationColumn(key: string) {
-    const filtered = columns.filter((col) => col.key !== key)
-    setColumns(filtered)
-  }
-
-  function editAnnotationColumn(key: string, name: string) {
-    const newColumns = columns.map((col) => col)
-    for (let i = 0; i < newColumns.length; i++) {
-      if (newColumns[i].key === key) {
-        newColumns[i].name = name
-      }
-    }
-    setColumns(newColumns)
-  }
-
   return (
-    <div
-      className={styles.container}
-      style={{
-        width: "100%",
-      }}
-    >
-      <div
-        className={styles.header}
-        style={{
-          width: "100%",
-          height: HEADING_SECTION_HEIGHT,
-        }}
-      >
-        <Typography
-          variant="h4"
-          sx={{
-            marginLeft: 1,
-          }}
-        >
-          Jobs
-        </Typography>
-        <div className={styles.actions}>
-          <div className={styles.actionItem}>
-            <ColumnSelect
-              height={HEADING_SECTION_HEIGHT - 16}
-              columns={columns}
-              onAddAnnotation={addAnnotationColumn}
-              onToggleColumn={toggleColumn}
-              onEditAnnotation={editAnnotationColumn}
-              onRemoveAnnotation={removeAnnotationColumn}
-            />
-          </div>
-          <div className={styles.actionItem}>
-            <Divider
-              orientation="vertical"
-              sx={{
-                height: HEADING_SECTION_HEIGHT - 16,
-              }}
-              className={styles.actionItem}
-            />
-          </div>
-          <div className={styles.actionItem}>
-            <Button
-              sx={{
-                maxHeight: HEADING_SECTION_HEIGHT - 16,
-              }}
-              className={styles.actionItem}
-              variant="contained"
-            >
-              Cancel
-            </Button>
-          </div>
-          <div className={styles.actionItem}>
-            <Button
-              sx={{
-                maxHeight: HEADING_SECTION_HEIGHT - 16,
-              }}
-              className={styles.actionItem}
-              variant="contained"
-            >
-              Reprioritize
-            </Button>
-          </div>
-        </div>
-      </div>
-      <div className={styles.jobsTable}>
-        <JobsTable
-          getJobsService={props.getJobsService}
-          groupJobsService={props.groupJobsService}
-          selectedColumns={columns}
-        />
-      </div>
+    <div className={styles.jobsTable}>
+      <JobsTable
+        getJobsService={props.getJobsService}
+        groupJobsService={props.groupJobsService}
+      />
     </div>
   )
 }

--- a/src/utils/jobsTableColumns.ts
+++ b/src/utils/jobsTableColumns.ts
@@ -45,7 +45,7 @@ const COLUMN_SPECS: ColumnSpec[] = [
 
 export const DEFAULT_COLUMNS: ColumnId[] = ["queue", "jobSet", "jobId", "state", "cpu", "memory", "ephemeralStorage"]
 
-export const DEFAULT_GROUPING: ColumnId[] = [];
+export const DEFAULT_GROUPING: ColumnId[] = []
 
 const COLUMN_SPEC_MAP = COLUMN_SPECS.reduce<Record<ColumnId, ColumnSpec>>((map, spec) => {
   map[spec.key] = spec

--- a/src/utils/jobsTableColumns.ts
+++ b/src/utils/jobsTableColumns.ts
@@ -43,7 +43,9 @@ const COLUMN_SPECS: ColumnSpec[] = [
   { key: "ephemeralStorage", name: "Eph. Storage", selected: true, isAnnotation: false, groupable: false, minSize: 95 },
 ]
 
-export const DEFAULT_COLUMNS: ColumnId[] = ["jobId", "jobSet", "queue", "state", "cpu", "memory", "ephemeralStorage"]
+export const DEFAULT_COLUMNS: ColumnId[] = ["queue", "jobSet", "jobId", "state", "cpu", "memory", "ephemeralStorage"]
+
+export const DEFAULT_GROUPING: ColumnId[] = ["queue", "jobSet"];
 
 const COLUMN_SPEC_MAP = COLUMN_SPECS.reduce<Record<ColumnId, ColumnSpec>>((map, spec) => {
   map[spec.key] = spec

--- a/src/utils/jobsTableColumns.ts
+++ b/src/utils/jobsTableColumns.ts
@@ -45,7 +45,7 @@ const COLUMN_SPECS: ColumnSpec[] = [
 
 export const DEFAULT_COLUMNS: ColumnId[] = ["queue", "jobSet", "jobId", "state", "cpu", "memory", "ephemeralStorage"]
 
-export const DEFAULT_GROUPING: ColumnId[] = ["queue", "jobSet"];
+export const DEFAULT_GROUPING: ColumnId[] = [];
 
 const COLUMN_SPEC_MAP = COLUMN_SPECS.reduce<Record<ColumnId, ColumnSpec>>((map, spec) => {
   map[spec.key] = spec


### PR DESCRIPTION
**On page load**
![image](https://user-images.githubusercontent.com/3807889/203773658-b4b39492-b64f-461c-877d-eba528c78205.png)

**Clicking dropdown**
![image](https://user-images.githubusercontent.com/3807889/203773894-3d3215cb-039d-491a-bd31-b57067cd3cf2.png)

**Selecting queue**
![image](https://user-images.githubusercontent.com/3807889/203773803-12c8019b-b026-460c-aa0e-e0d522d791c6.png)

**Remaining options**
![image](https://user-images.githubusercontent.com/3807889/203774026-66aa0c94-a401-41c1-a533-41180c90f086.png)

**No remaining options**
![image](https://user-images.githubusercontent.com/3807889/203774099-76ee364e-55f9-45e0-b04a-f452f79de946.png)

**Modifying a grouped column**
![image](https://user-images.githubusercontent.com/3807889/203774966-405e09ec-a4d9-4d14-a944-6e2bcf017e47.png)

**Cant unselect grouped columns**
![image](https://user-images.githubusercontent.com/3807889/203774655-51140ef2-3b5f-4d56-a7df-85d7bbe567b2.png)

- Moves column grouping controls to the top of the table (closer to the mocks)
- Prevents the user from unselecting columns that are grouped
- Fixes "selected columns" count
- Fix bug where changing non-leaf group caused table problems
- Makes use of flexbox to ensure a consistent action height along the action bar
- Removes unnecessary "React" imports
- Slims up grouped rows