### PR TITLE
Allow selecting of jobs

### DIFF
--- a/src/components/jobsTable/JobsTable.test.tsx
+++ b/src/components/jobsTable/JobsTable.test.tsx
@@ -1,4 +1,3 @@
-import { expect, jest } from "@jest/globals"
 import { render, within, waitFor, waitForElementToBeRemoved, screen } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { Job } from "model"
@@ -175,6 +174,30 @@ describe("JobsTable", () => {
     waitForElementToBeRemoved(() => queryAllByRole("button", { name: "Expand row" }))
   })
 
+  it("should allow selecting of jobs", async () => {
+    const { getByRole, findByRole } = renderComponent()
+    await waitForElementToBeRemoved(() => getByRole("progressbar"))
+
+    expect(await findByRole("button", {name: "Cancel"})).toBeDisabled()
+    expect(await findByRole("button", {name: "Reprioritize"})).toBeDisabled()
+
+    toggleSelectedRow(jobs[0].jobId);
+    toggleSelectedRow(jobs[2].jobId);
+
+    expect(await findByRole("button", {name: "Cancel 2 jobs"})).toBeEnabled()
+    expect(await findByRole("button", {name: "Reprioritize 2 jobs"})).toBeEnabled()
+
+    toggleSelectedRow(jobs[2].jobId);
+
+    expect(await findByRole("button", {name: "Cancel 1 job"})).toBeEnabled()
+    expect(await findByRole("button", {name: "Reprioritize 1 job"})).toBeEnabled()
+
+    toggleSelectedRow(jobs[0].jobId);
+
+    expect(await findByRole("button", {name: "Cancel"})).toBeDisabled()
+    expect(await findByRole("button", {name: "Reprioritize"})).toBeDisabled()
+  })
+
   async function assertNumDataRowsShown(nDataRows: number) {
     await waitFor(async () => {
       const rows = await screen.findAllByRole("row")
@@ -197,5 +220,11 @@ describe("JobsTable", () => {
     })
     const expandButton = within(rowToExpand).getByRole("button", { name: "Expand row" })
     userEvent.click(expandButton)
+  }
+
+  async function toggleSelectedRow(jobId: string) {
+    const matchingRow = await screen.findByRole("row", { name: "job:" + jobId })
+    const checkbox = await within(matchingRow).findByRole("checkbox");
+    userEvent.click(checkbox);
   }
 })

--- a/src/components/jobsTable/JobsTable.test.tsx
+++ b/src/components/jobsTable/JobsTable.test.tsx
@@ -178,24 +178,24 @@ describe("JobsTable", () => {
     const { getByRole, findByRole } = renderComponent()
     await waitForElementToBeRemoved(() => getByRole("progressbar"))
 
-    expect(await findByRole("button", {name: "Cancel"})).toBeDisabled()
-    expect(await findByRole("button", {name: "Reprioritize"})).toBeDisabled()
+    expect(await findByRole("button", { name: "Cancel" })).toBeDisabled()
+    expect(await findByRole("button", { name: "Reprioritize" })).toBeDisabled()
 
-    toggleSelectedRow(jobs[0].jobId);
-    toggleSelectedRow(jobs[2].jobId);
+    toggleSelectedRow(jobs[0].jobId)
+    toggleSelectedRow(jobs[2].jobId)
 
-    expect(await findByRole("button", {name: "Cancel 2 jobs"})).toBeEnabled()
-    expect(await findByRole("button", {name: "Reprioritize 2 jobs"})).toBeEnabled()
+    expect(await findByRole("button", { name: "Cancel 2 jobs" })).toBeEnabled()
+    expect(await findByRole("button", { name: "Reprioritize 2 jobs" })).toBeEnabled()
 
-    toggleSelectedRow(jobs[2].jobId);
+    toggleSelectedRow(jobs[2].jobId)
 
-    expect(await findByRole("button", {name: "Cancel 1 job"})).toBeEnabled()
-    expect(await findByRole("button", {name: "Reprioritize 1 job"})).toBeEnabled()
+    expect(await findByRole("button", { name: "Cancel 1 job" })).toBeEnabled()
+    expect(await findByRole("button", { name: "Reprioritize 1 job" })).toBeEnabled()
 
-    toggleSelectedRow(jobs[0].jobId);
+    toggleSelectedRow(jobs[0].jobId)
 
-    expect(await findByRole("button", {name: "Cancel"})).toBeDisabled()
-    expect(await findByRole("button", {name: "Reprioritize"})).toBeDisabled()
+    expect(await findByRole("button", { name: "Cancel" })).toBeDisabled()
+    expect(await findByRole("button", { name: "Reprioritize" })).toBeDisabled()
   })
 
   async function assertNumDataRowsShown(nDataRows: number) {
@@ -224,7 +224,7 @@ describe("JobsTable", () => {
 
   async function toggleSelectedRow(jobId: string) {
     const matchingRow = await screen.findByRole("row", { name: "job:" + jobId })
-    const checkbox = await within(matchingRow).findByRole("checkbox");
-    userEvent.click(checkbox);
+    const checkbox = await within(matchingRow).findByRole("checkbox")
+    userEvent.click(checkbox)
   }
 })

--- a/src/components/jobsTable/JobsTable.test.tsx
+++ b/src/components/jobsTable/JobsTable.test.tsx
@@ -178,7 +178,7 @@ describe("JobsTable", () => {
   async function assertNumDataRowsShown(nDataRows: number) {
     await waitFor(async () => {
       const rows = await screen.findAllByRole("row")
-      expect(rows.length).toBe(nDataRows + 1) // One row per data row, plus the header row
+      expect(rows.length).toBe(nDataRows + 2) // One row per data row, plus the header and footer rows
     })
   }
 

--- a/src/components/jobsTable/JobsTable.tsx
+++ b/src/components/jobsTable/JobsTable.tsx
@@ -135,7 +135,9 @@ export const JobsTable = ({ getJobsService, groupJobsService }: JobsPageProps) =
 
   const onGroupingChange = useCallback(
     (newState: ColumnId[]) => {
-      setExpanded({}) // Reset currently-expanded when grouping changes
+      // Reset currently expanded/selected when grouping changes
+      setSelectedRows({})
+      setExpanded({}) 
 
       // Check all grouping columns are displayed
       setAllColumns(
@@ -197,7 +199,6 @@ export const JobsTable = ({ getJobsService, groupJobsService }: JobsPageProps) =
 
     // Grouping
     manualGrouping: true,
-    // onGroupingChange: onGroupingChange,
     getGroupedRowModel: getGroupedRowModel(),
     getExpandedRowModel: getExpandedRowModel(),
     onExpandedChange: (updatedState) => setExpanded(normaliseExpandedState(updatedState, expanded, table)),

--- a/src/components/jobsTable/JobsTable.tsx
+++ b/src/components/jobsTable/JobsTable.tsx
@@ -45,6 +45,7 @@ import { JobsTableActionBar } from "./JobsTableActionBar"
 import { getSelectedColumnDef } from "./SelectedColumn"
 import { useStateWithPrevious } from "hooks/useStateWithPrevious"
 import _ from "lodash"
+import { JobId } from "model"
 
 const DEFAULT_PAGE_SIZE = 30
 
@@ -65,6 +66,14 @@ export const JobsTable = ({ getJobsService, groupJobsService }: JobsPageProps) =
     [expanded, prevExpanded],
   )
   const [selectedRows, setSelectedRows] = useState<RowSelectionState>({})
+  const selectedJobs: JobId[] = useMemo(() => 
+    Object.keys(selectedRows)
+      .map((rowId) => {
+        const {rowIdPartsPath} = fromRowId(rowId as RowId)
+        return rowIdPartsPath.find(part => part.type === "job")?.value;
+      })
+      .filter((jobId): jobId is JobId => jobId !== undefined),
+    [selectedRows]);
 
   const [pagination, setPagination, prevPagination] = useStateWithPrevious<PaginationState>({
     pageIndex: 0,
@@ -265,6 +274,7 @@ export const JobsTable = ({ getJobsService, groupJobsService }: JobsPageProps) =
       <JobsTableActionBar
         allColumns={allColumns}
         groupedColumns={grouping}
+        selectedJobs={selectedJobs}
         onColumnsChanged={setAllColumns}
         onGroupsChanged={onGroupingChange}
       />

--- a/src/components/jobsTable/JobsTable.tsx
+++ b/src/components/jobsTable/JobsTable.tsx
@@ -66,14 +66,16 @@ export const JobsTable = ({ getJobsService, groupJobsService }: JobsPageProps) =
     [expanded, prevExpanded],
   )
   const [selectedRows, setSelectedRows] = useState<RowSelectionState>({})
-  const selectedJobs: JobId[] = useMemo(() => 
-    Object.keys(selectedRows)
-      .map((rowId) => {
-        const {rowIdPartsPath} = fromRowId(rowId as RowId)
-        return rowIdPartsPath.find(part => part.type === "job")?.value;
-      })
-      .filter((jobId): jobId is JobId => jobId !== undefined),
-    [selectedRows]);
+  const selectedJobs: JobId[] = useMemo(
+    () =>
+      Object.keys(selectedRows)
+        .map((rowId) => {
+          const { rowIdPartsPath } = fromRowId(rowId as RowId)
+          return rowIdPartsPath.find((part) => part.type === "job")?.value
+        })
+        .filter((jobId): jobId is JobId => jobId !== undefined),
+    [selectedRows],
+  )
 
   const [pagination, setPagination, prevPagination] = useStateWithPrevious<PaginationState>({
     pageIndex: 0,
@@ -279,7 +281,7 @@ export const JobsTable = ({ getJobsService, groupJobsService }: JobsPageProps) =
         onGroupsChanged={onGroupingChange}
       />
       <TableContainer component={Paper}>
-        <Table sx={{tableLayout: "auto"}}>
+        <Table sx={{ tableLayout: "auto" }}>
           <TableHead>
             {table.getHeaderGroups().map((headerGroup) => (
               <TableRow key={headerGroup.id}>

--- a/src/components/jobsTable/JobsTable.tsx
+++ b/src/components/jobsTable/JobsTable.tsx
@@ -217,17 +217,19 @@ export const JobsTable = ({ getJobsService, groupJobsService }: JobsPageProps) =
     getFilteredRowModel: getFilteredRowModel(),
   })
 
-  console.log({selectedRows});
-
   // Update any new children of selected rows
-  useEffect(() => {
+  useMemo(() => {
     console.log({selectedRows});
     const selectedRowIds = Object.keys(selectedRows) as RowId[];
     selectedRowIds.forEach(rowId => {
       try {
         const row = table.getRow(rowId);
         if (row.getIsSelected() && !row.getIsSomeSelected()) {
-          row.subRows.forEach(subRow => subRow.toggleSelected(true))
+          row.subRows.forEach(subRow => {
+            if (!subRow.getIsSelected()) {
+              subRow.toggleSelected(true)
+            }
+          })
         }
       } catch (e) {
         console.warn("Could not update all selected subrows for row: " + rowId, e);
@@ -261,7 +263,11 @@ export const JobsTable = ({ getJobsService, groupJobsService }: JobsPageProps) =
             ))}
           </TableHead>
 
-          <JobsTableBody dataIsLoading={isLoading} columns={selectedColumnDefs} rowsToRender={rowsToRender} tableState={tableState} />
+          <JobsTableBody 
+            dataIsLoading={isLoading} 
+            columns={selectedColumnDefs} 
+            rowsToRender={rowsToRender} 
+          />
         </Table>
       </TableContainer>
 
@@ -282,11 +288,8 @@ interface JobsTableBodyProps {
   dataIsLoading: boolean
   columns: ColumnDef<JobTableRow>[]
   rowsToRender: Row<JobTableRow>[]
-
-  // Used to bust the memo cache if table state changes
-  tableState: Partial<TableState>
 }
-const JobsTableBody = memo(({ dataIsLoading, columns, rowsToRender }: JobsTableBodyProps) => {
+const JobsTableBody = ({ dataIsLoading, columns, rowsToRender }: JobsTableBodyProps) => {
   // This memoized component saves re-rendering if the data to display hasn't changed
   const canDisplay = !dataIsLoading && rowsToRender.length > 0
   return (
@@ -324,4 +327,4 @@ const JobsTableBody = memo(({ dataIsLoading, columns, rowsToRender }: JobsTableB
       })}
     </TableBody>
   )
-})
+}

--- a/src/components/jobsTable/JobsTable.tsx
+++ b/src/components/jobsTable/JobsTable.tsx
@@ -274,12 +274,12 @@ export const JobsTable = ({ getJobsService, groupJobsService }: JobsPageProps) =
       <JobsTableActionBar
         allColumns={allColumns}
         groupedColumns={grouping}
-        selectedJobs={selectedJobs}
+        selectedJobs={selectedJobs} // TODO: This may need to be change to reflect that queues/jobsets can be selected (e.g. to cancel all within)
         onColumnsChanged={setAllColumns}
         onGroupsChanged={onGroupingChange}
       />
       <TableContainer component={Paper}>
-        <Table>
+        <Table sx={{tableLayout: "auto"}}>
           <TableHead>
             {table.getHeaderGroups().map((headerGroup) => (
               <TableRow key={headerGroup.id}>

--- a/src/components/jobsTable/JobsTableActionBar.tsx
+++ b/src/components/jobsTable/JobsTableActionBar.tsx
@@ -46,7 +46,7 @@ export const JobsTableActionBar = memo(
       onColumnsChanged(newColumns)
     }
 
-    const jobCount = selectedJobs.length;
+    const jobCount = selectedJobs.length
     const jobCountString = `${jobCount} job${jobCount === 1 ? "" : "s"}`
 
     return (
@@ -65,8 +65,12 @@ export const JobsTableActionBar = memo(
             onRemoveAnnotation={removeAnnotationColumn}
           />
           <Divider orientation="vertical" />
-          <Button variant="contained" disabled={jobCount === 0}>Cancel{jobCount > 0 ? ` ${jobCountString}` : ""}</Button>
-          <Button variant="contained" disabled={jobCount === 0}>Reprioritize{jobCount > 0 ? ` ${jobCountString}` : ""}</Button>
+          <Button variant="contained" disabled={jobCount === 0}>
+            Cancel{jobCount > 0 ? ` ${jobCountString}` : ""}
+          </Button>
+          <Button variant="contained" disabled={jobCount === 0}>
+            Reprioritize{jobCount > 0 ? ` ${jobCountString}` : ""}
+          </Button>
         </div>
       </div>
     )

--- a/src/components/jobsTable/JobsTableActionBar.tsx
+++ b/src/components/jobsTable/JobsTableActionBar.tsx
@@ -4,15 +4,17 @@ import { ColumnSpec, columnSpecFor, ColumnId } from "utils/jobsTableColumns"
 import styles from "./JobsTableActionBar.module.css"
 import GroupBySelect from "components/GroupBySelect"
 import { memo } from "react"
+import { JobId } from "model"
 
 export interface JobsTableActionBarProps {
   allColumns: ColumnSpec[]
   groupedColumns: ColumnId[]
+  selectedJobs: JobId[]
   onColumnsChanged: (newColumns: ColumnSpec[]) => void
   onGroupsChanged: (newGroups: ColumnId[]) => void
 }
 export const JobsTableActionBar = memo(
-  ({ allColumns, groupedColumns, onColumnsChanged, onGroupsChanged }: JobsTableActionBarProps) => {
+  ({ allColumns, groupedColumns, selectedJobs, onColumnsChanged, onGroupsChanged }: JobsTableActionBarProps) => {
     function toggleColumn(key: string) {
       const newColumns = allColumns.map((col) => ({
         ...col,
@@ -44,6 +46,9 @@ export const JobsTableActionBar = memo(
       onColumnsChanged(newColumns)
     }
 
+    const jobCount = selectedJobs.length;
+    const jobCountString = `${jobCount} job${jobCount === 1 ? "" : "s"}`
+
     return (
       <div className={styles.actionBar}>
         <div className={styles.actionGroup}>
@@ -60,8 +65,8 @@ export const JobsTableActionBar = memo(
             onRemoveAnnotation={removeAnnotationColumn}
           />
           <Divider orientation="vertical" />
-          <Button variant="contained">Cancel</Button>
-          <Button variant="contained">Reprioritize</Button>
+          <Button variant="contained" disabled={jobCount === 0}>Cancel{jobCount > 0 ? ` ${jobCountString}` : ""}</Button>
+          <Button variant="contained" disabled={jobCount === 0}>Reprioritize{jobCount > 0 ? ` ${jobCountString}` : ""}</Button>
         </div>
       </div>
     )

--- a/src/components/jobsTable/JobsTableActionBar.tsx
+++ b/src/components/jobsTable/JobsTableActionBar.tsx
@@ -3,6 +3,7 @@ import ColumnSelect from "components/ColumnSelect"
 import { ColumnSpec, columnSpecFor, ColumnId } from "utils/jobsTableColumns"
 import styles from "./JobsTableActionBar.module.css"
 import GroupBySelect from "components/GroupBySelect"
+import { memo } from "react"
 
 export interface JobsTableActionBarProps {
   allColumns: ColumnSpec[]
@@ -10,62 +11,59 @@ export interface JobsTableActionBarProps {
   onColumnsChanged: (newColumns: ColumnSpec[]) => void
   onGroupsChanged: (newGroups: ColumnId[]) => void
 }
-export const JobsTableActionBar = ({
-  allColumns,
-  groupedColumns,
-  onColumnsChanged,
-  onGroupsChanged,
-}: JobsTableActionBarProps) => {
-  function toggleColumn(key: string) {
-    const newColumns = allColumns.map((col) => ({
-      ...col,
-      selected: col.key === key ? !col.selected : col.selected,
-    }))
-    onColumnsChanged(newColumns)
-  }
+export const JobsTableActionBar = memo(
+  ({ allColumns, groupedColumns, onColumnsChanged, onGroupsChanged }: JobsTableActionBarProps) => {
+    function toggleColumn(key: string) {
+      const newColumns = allColumns.map((col) => ({
+        ...col,
+        selected: col.key === key ? !col.selected : col.selected,
+      }))
+      onColumnsChanged(newColumns)
+    }
 
-  function addAnnotationColumn(name: string) {
-    const newColumns = allColumns.concat([
-      {
-        ...columnSpecFor(name as ColumnId),
-        isAnnotation: true,
-      },
-    ])
-    onColumnsChanged(newColumns)
-  }
+    function addAnnotationColumn(name: string) {
+      const newColumns = allColumns.concat([
+        {
+          ...columnSpecFor(name as ColumnId),
+          isAnnotation: true,
+        },
+      ])
+      onColumnsChanged(newColumns)
+    }
 
-  function removeAnnotationColumn(key: string) {
-    const filtered = allColumns.filter((col) => !col.isAnnotation || col.key !== key)
-    onColumnsChanged(filtered)
-  }
+    function removeAnnotationColumn(key: string) {
+      const filtered = allColumns.filter((col) => !col.isAnnotation || col.key !== key)
+      onColumnsChanged(filtered)
+    }
 
-  function editAnnotationColumn(key: string, newName: string) {
-    const newColumns = allColumns.map((col) => ({
-      ...col,
-      name: col.key === key ? newName : col.name,
-    }))
-    onColumnsChanged(newColumns)
-  }
+    function editAnnotationColumn(key: string, newName: string) {
+      const newColumns = allColumns.map((col) => ({
+        ...col,
+        name: col.key === key ? newName : col.name,
+      }))
+      onColumnsChanged(newColumns)
+    }
 
-  return (
-    <div className={styles.actionBar}>
-      <div className={styles.actionGroup}>
-        <GroupBySelect columns={allColumns} groups={groupedColumns} onGroupsChanged={onGroupsChanged} />
+    return (
+      <div className={styles.actionBar}>
+        <div className={styles.actionGroup}>
+          <GroupBySelect columns={allColumns} groups={groupedColumns} onGroupsChanged={onGroupsChanged} />
+        </div>
+
+        <div className={styles.actionGroup}>
+          <ColumnSelect
+            allColumns={allColumns}
+            groupedColumns={groupedColumns}
+            onAddAnnotation={addAnnotationColumn}
+            onToggleColumn={toggleColumn}
+            onEditAnnotation={editAnnotationColumn}
+            onRemoveAnnotation={removeAnnotationColumn}
+          />
+          <Divider orientation="vertical" />
+          <Button variant="contained">Cancel</Button>
+          <Button variant="contained">Reprioritize</Button>
+        </div>
       </div>
-
-      <div className={styles.actionGroup}>
-        <ColumnSelect
-          allColumns={allColumns}
-          groupedColumns={groupedColumns}
-          onAddAnnotation={addAnnotationColumn}
-          onToggleColumn={toggleColumn}
-          onEditAnnotation={editAnnotationColumn}
-          onRemoveAnnotation={removeAnnotationColumn}
-        />
-        <Divider orientation="vertical" />
-        <Button variant="contained">Cancel</Button>
-        <Button variant="contained">Reprioritize</Button>
-      </div>
-    </div>
-  )
-}
+    )
+  },
+)

--- a/src/components/jobsTable/JobsTableCell.tsx
+++ b/src/components/jobsTable/JobsTableCell.tsx
@@ -32,7 +32,9 @@ export const HeaderCell = ({ header, hoveredColumn, onHoverChange }: HeaderCellP
       align={isRightAligned ? "right" : "left"}
       size="small"
       sx={{
-        minWidth: header.column.getSize(),
+        minWidth: `${header.column.getSize()}px`,
+        width: `${header.column.getSize()}px`,
+        maxWidth: `${header.column.getSize()}px`,
         lineHeight: "2.5em", // Provides enough height for icon buttons
         ...sharedCellStyle,
       }}

--- a/src/components/jobsTable/JobsTableCell.tsx
+++ b/src/components/jobsTable/JobsTableCell.tsx
@@ -50,7 +50,6 @@ export const HeaderCell = ({ header, hoveredColumn, onHoverChange }: HeaderCellP
 
 export interface BodyCellProps {
   cell: Cell<JobRow, unknown>
-  // cellContents: JSX.Element
   rowIsGroup: boolean
   rowIsExpanded: boolean
   onExpandedChange: () => void

--- a/src/components/jobsTable/JobsTableCell.tsx
+++ b/src/components/jobsTable/JobsTableCell.tsx
@@ -53,6 +53,7 @@ export const HeaderCell = ({ header, hoveredColumn, onHoverChange }: HeaderCellP
 
 export interface BodyCellProps {
   cell: Cell<JobRow, unknown>
+  // cellContents: JSX.Element
   rowIsGroup: boolean
   rowIsExpanded: boolean
   onExpandedChange: () => void
@@ -71,7 +72,6 @@ export const BodyCell = ({ cell, rowIsGroup, rowIsExpanded, onExpandedChange, su
         ...sharedCellStyle,
       }}
     >
-      {/* {rowIsGrouped && cell.column.getIsGrouped() && cellHasValue ? ( */}
       {rowIsGroup && cell.column.getIsGrouped() && cellHasValue ? (
         // If it's a grouped cell, add an expander and row count
         <>

--- a/src/components/jobsTable/JobsTableCell.tsx
+++ b/src/components/jobsTable/JobsTableCell.tsx
@@ -30,11 +30,8 @@ export const HeaderCell = ({ header, hoveredColumn, onHoverChange }: HeaderCellP
     <TableCell
       key={id}
       align={isRightAligned ? "right" : "left"}
-      size="small"
       sx={{
-        minWidth: `${header.column.getSize()}px`,
         width: `${header.column.getSize()}px`,
-        maxWidth: `${header.column.getSize()}px`,
         lineHeight: "2.5em", // Provides enough height for icon buttons
         ...sharedCellStyle,
       }}

--- a/src/components/jobsTable/SelectedColumn.tsx
+++ b/src/components/jobsTable/SelectedColumn.tsx
@@ -8,7 +8,7 @@ const Checkbox = memo(MuiCheckbox)
 
 export const SELECT_COLUMN_ID: ColumnId = "selectorCol"
 export const getSelectedColumnDef = (): ColumnDef<JobTableRow> => {
-  const fixedWidthPixels = 50;
+  const fixedWidthPixels = 50
   return {
     id: SELECT_COLUMN_ID as ColumnId,
     minSize: fixedWidthPixels,

--- a/src/components/jobsTable/SelectedColumn.tsx
+++ b/src/components/jobsTable/SelectedColumn.tsx
@@ -1,42 +1,44 @@
-import { Checkbox } from "@mui/material";
-import { ColumnDef } from "@tanstack/react-table";
-import { JobTableRow } from "models/jobsTableModels";
-import { ColumnId } from "utils/jobsTableColumns";
+import { Checkbox as MuiCheckbox } from "@mui/material"
+import { ColumnDef } from "@tanstack/react-table"
+import { JobTableRow } from "models/jobsTableModels"
+import { memo, useCallback, useMemo } from "react"
+import { ColumnId } from "utils/jobsTableColumns"
 
-export const SELECT_COLUMN_ID: ColumnId = 'selectorCol';
+const Checkbox = memo(MuiCheckbox)
+
+export const SELECT_COLUMN_ID: ColumnId = "selectorCol"
 export const getSelectedColumnDef = (): ColumnDef<JobTableRow> => {
-    return {
-        id: SELECT_COLUMN_ID,
-        minSize: 5,
-        size: 5,
-        maxSize: 5,
-        // aggregationFn: undefined,
-        aggregatedCell: undefined,
-        header: ({ table }) => {
-            return (
-                <Checkbox
-                    checked={table.getIsAllRowsSelected()}
-                    indeterminate={table.getIsSomeRowsSelected()}
-                    onChange={table.getToggleAllRowsSelectedHandler()}
-                    size="small"
-                // sx={{height: "1.5em", width: "1.5em"}}
-                />
-            )
-        },
-        cell: ({ row, column }) => {
-            // console.log({row, checked: row.getIsSelected(), indeterminate: row.getIsSomeSelected()})
-            return (
-                <Checkbox
-                    checked={row.getIsGrouped() ? row.getIsAllSubRowsSelected() : row.getIsSelected()}
-                    indeterminate={row.getIsSomeSelected()}
-                    onChange={row.getToggleSelectedHandler()}
-                    size="small"
-                    sx={{
-                        marginLeft: `${row.depth}em`
-                    }}
-                // sx={{height: "1.5em", width: "1.5em"}}
-                />
-            )
-        },
-    };
+  return {
+    id: SELECT_COLUMN_ID,
+    minSize: 5,
+    size: 5,
+    maxSize: 5,
+    aggregatedCell: undefined,
+    header: ({ table }) => {
+      return (
+        <Checkbox
+          checked={table.getIsAllRowsSelected()}
+          indeterminate={table.getIsSomeRowsSelected()}
+          onChange={table.getToggleAllRowsSelectedHandler()}
+          size="small"
+        />
+      )
+    },
+    cell: ({ row }) => {
+      return (
+        <Checkbox
+          checked={row.getIsGrouped() ? row.getIsAllSubRowsSelected() : row.getIsSelected()}
+          indeterminate={row.getIsSomeSelected()}
+          onChange={useCallback(row.getToggleSelectedHandler(), [row])}
+          size="small"
+          sx={useMemo(
+            () => ({
+              marginLeft: `${row.depth}em`,
+            }),
+            [],
+          )}
+        />
+      )
+    },
+  }
 }

--- a/src/components/jobsTable/SelectedColumn.tsx
+++ b/src/components/jobsTable/SelectedColumn.tsx
@@ -1,0 +1,42 @@
+import { Checkbox } from "@mui/material";
+import { ColumnDef } from "@tanstack/react-table";
+import { JobTableRow } from "models/jobsTableModels";
+import { ColumnId } from "utils/jobsTableColumns";
+
+export const SELECT_COLUMN_ID: ColumnId = 'selectorCol';
+export const getSelectedColumnDef = (): ColumnDef<JobTableRow> => {
+    return {
+        id: SELECT_COLUMN_ID,
+        minSize: 5,
+        size: 5,
+        maxSize: 5,
+        // aggregationFn: undefined,
+        aggregatedCell: undefined,
+        header: ({ table }) => {
+            return (
+                <Checkbox
+                    checked={table.getIsAllRowsSelected()}
+                    indeterminate={table.getIsSomeRowsSelected()}
+                    onChange={table.getToggleAllRowsSelectedHandler()}
+                    size="small"
+                // sx={{height: "1.5em", width: "1.5em"}}
+                />
+            )
+        },
+        cell: ({ row, column }) => {
+            // console.log({row, checked: row.getIsSelected(), indeterminate: row.getIsSomeSelected()})
+            return (
+                <Checkbox
+                    checked={row.getIsGrouped() ? row.getIsAllSubRowsSelected() : row.getIsSelected()}
+                    indeterminate={row.getIsSomeSelected()}
+                    onChange={row.getToggleSelectedHandler()}
+                    size="small"
+                    sx={{
+                        marginLeft: `${row.depth}em`
+                    }}
+                // sx={{height: "1.5em", width: "1.5em"}}
+                />
+            )
+        },
+    };
+}

--- a/src/components/jobsTable/SelectedColumn.tsx
+++ b/src/components/jobsTable/SelectedColumn.tsx
@@ -8,11 +8,12 @@ const Checkbox = memo(MuiCheckbox)
 
 export const SELECT_COLUMN_ID: ColumnId = "selectorCol"
 export const getSelectedColumnDef = (): ColumnDef<JobTableRow> => {
+  const fixedWidthPixels = 50;
   return {
-    id: SELECT_COLUMN_ID,
-    minSize: 5,
-    size: 5,
-    maxSize: 5,
+    id: SELECT_COLUMN_ID as ColumnId,
+    minSize: fixedWidthPixels,
+    size: fixedWidthPixels,
+    maxSize: fixedWidthPixels,
     aggregatedCell: undefined,
     header: ({ table }) => {
       return (

--- a/src/hooks/useStateWithPrevious.ts
+++ b/src/hooks/useStateWithPrevious.ts
@@ -1,0 +1,8 @@
+import { Dispatch, SetStateAction, useState } from "react"
+import { usePrevious } from "./usePrevious"
+
+export const useStateWithPrevious = <T>(value: T): [T, Dispatch<SetStateAction<T>>, T?] => {
+  const [currentValue, setCurrentValue] = useState(value)
+  const previousValue = usePrevious(currentValue)
+  return [currentValue, setCurrentValue, previousValue]
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -10,7 +10,7 @@ import "./index.css"
 const root = ReactDOM.createRoot(document.getElementById("root") as HTMLElement)
 root.render(
   <React.StrictMode>
-    <App />,
+    <App />
   </React.StrictMode>,
 )
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -10,7 +10,7 @@ import "./index.css"
 const root = ReactDOM.createRoot(document.getElementById("root") as HTMLElement)
 root.render(
   <React.StrictMode>
-  <App />,
+    <App />,
   </React.StrictMode>,
 )
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -10,7 +10,7 @@ import "./index.css"
 const root = ReactDOM.createRoot(document.getElementById("root") as HTMLElement)
 root.render(
   <React.StrictMode>
-    <App />
+  <App />,
   </React.StrictMode>,
 )
 

--- a/src/model.ts
+++ b/src/model.ts
@@ -25,8 +25,10 @@ type ColoredState = {
   color: string
 }
 
+export type JobId = string;
+
 export type Job = {
-  jobId: string
+  jobId: JobId
   queue: string
   owner: string
   jobSet: string

--- a/src/model.ts
+++ b/src/model.ts
@@ -25,7 +25,7 @@ type ColoredState = {
   color: string
 }
 
-export type JobId = string;
+export type JobId = string
 
 export type Job = {
   jobId: JobId

--- a/src/utils/jobsTableColumns.ts
+++ b/src/utils/jobsTableColumns.ts
@@ -1,7 +1,7 @@
 import { capitalize } from "lodash"
 import { Job } from "model"
 
-export type ColumnId = keyof Job
+export type ColumnId = keyof Job | 'selectorCol';
 export type ColumnSpec = {
   key: ColumnId
   name: string

--- a/src/utils/jobsTableColumns.ts
+++ b/src/utils/jobsTableColumns.ts
@@ -1,4 +1,3 @@
-import { getSelectedColumnDef } from "components/jobsTable/SelectedColumn"
 import { capitalize } from "lodash"
 import { Job } from "model"
 

--- a/src/utils/jobsTableColumns.ts
+++ b/src/utils/jobsTableColumns.ts
@@ -1,3 +1,4 @@
+import { getSelectedColumnDef } from "components/jobsTable/SelectedColumn"
 import { capitalize } from "lodash"
 import { Job } from "model"
 

--- a/src/utils/jobsTableColumns.ts
+++ b/src/utils/jobsTableColumns.ts
@@ -1,7 +1,7 @@
 import { capitalize } from "lodash"
 import { Job } from "model"
 
-export type ColumnId = keyof Job | 'selectorCol';
+export type ColumnId = keyof Job | "selectorCol"
 export type ColumnSpec = {
   key: ColumnId
   name: string

--- a/src/utils/jobsTableUtils.test.ts
+++ b/src/utils/jobsTableUtils.test.ts
@@ -1,4 +1,4 @@
-import { convertExpandedRowFieldsToFilters } from "./jobsTableUtils"
+import { convertExpandedRowFieldsToFilters, diffOfKeys } from "./jobsTableUtils"
 
 describe("JobsTableUtils", () => {
   describe("convertExpandedRowFieldsToFilters", () => {
@@ -38,6 +38,50 @@ describe("JobsTableUtils", () => {
           match: "exact",
         },
       ])
+    })
+  })
+
+  describe("diffOfKeys", () => {
+    it("detects added keys", () => {
+      const newObject = {
+        hello: 5,
+      }
+      const previousObject = {}
+
+      const [addedKeys, removedKeys] = diffOfKeys<string>(newObject, previousObject)
+
+      expect(addedKeys).toStrictEqual(["hello"])
+      expect(removedKeys).toStrictEqual([])
+    })
+
+    it("detects removed keys", () => {
+      const newObject = {}
+      const previousObject = {
+        hello: 5,
+      }
+
+      const [addedKeys, removedKeys] = diffOfKeys<string>(newObject, previousObject)
+
+      expect(addedKeys).toStrictEqual([])
+      expect(removedKeys).toStrictEqual(["hello"])
+    })
+
+    it("handles multiple added and removed keys", () => {
+      const newObject = {
+        c: 101,
+        d: 103,
+        e: 104,
+      }
+      const previousObject = {
+        a: 1,
+        b: 2,
+        c: 3,
+      }
+
+      const [addedKeys, removedKeys] = diffOfKeys<string>(newObject, previousObject)
+
+      expect(addedKeys).toStrictEqual(["d", "e"])
+      expect(removedKeys).toStrictEqual(["a", "b"])
     })
   })
 })

--- a/src/utils/jobsTableUtils.ts
+++ b/src/utils/jobsTableUtils.ts
@@ -1,5 +1,7 @@
+import { ExpandedState, Table, Updater } from "@tanstack/react-table"
+import _ from "lodash"
 import { Job, JobFilter, JobGroup, JobOrder } from "model"
-import { JobRow, JobGroupRow } from "models/jobsTableModels"
+import { JobRow, JobGroupRow, JobTableRow } from "models/jobsTableModels"
 import GetJobsService from "services/GetJobsService"
 import GroupJobsService from "services/GroupJobsService"
 import { RowIdParts, toRowId, RowId } from "./reactTableUtils"
@@ -68,4 +70,30 @@ export const groupsToRows = (
       subRows: [], // Will be set later if expanded
     }),
   )
+}
+
+export const diffOfKeys = <K extends string | number | symbol>(
+  currentObject?: Record<K, unknown>,
+  oldObject?: Record<K, unknown>,
+): [K[], K[]] => {
+  const currentKeys = new Set(Object.keys(currentObject ?? {}) as K[])
+  const prevKeys = new Set(Object.keys(oldObject ?? {}) as K[])
+
+  const addedKeys = Array.from(currentKeys).filter((e) => !prevKeys.has(e))
+  const removedKeys = Array.from(prevKeys).filter((e) => !currentKeys.has(e))
+  return [addedKeys, removedKeys]
+}
+
+export const normaliseExpandedState = (
+  updaterOrValue: Updater<ExpandedState>,
+  currentState: ExpandedState,
+  table: Table<JobTableRow>,
+) => {
+  const newValue = typeof updaterOrValue === "function" ? updaterOrValue(currentState) : updaterOrValue
+  if (typeof newValue === "boolean") {
+    const allRowsExpanded = _.fromPairs(table.getRowModel().flatRows.map((r) => [r.id, true]))
+    return allRowsExpanded
+  } else {
+    return newValue
+  }
 }

--- a/src/utils/jobsTableUtils.ts
+++ b/src/utils/jobsTableUtils.ts
@@ -1,7 +1,7 @@
-import { ExpandedState, Table, Updater } from "@tanstack/react-table"
+import { Updater } from "@tanstack/react-table"
 import _ from "lodash"
 import { Job, JobFilter, JobGroup, JobOrder } from "model"
-import { JobRow, JobGroupRow, JobTableRow } from "models/jobsTableModels"
+import { JobRow, JobGroupRow } from "models/jobsTableModels"
 import GetJobsService from "services/GetJobsService"
 import GroupJobsService from "services/GroupJobsService"
 import { RowIdParts, toRowId, RowId } from "./reactTableUtils"
@@ -84,16 +84,6 @@ export const diffOfKeys = <K extends string | number | symbol>(
   return [addedKeys, removedKeys]
 }
 
-export const normaliseExpandedState = (
-  updaterOrValue: Updater<ExpandedState>,
-  currentState: ExpandedState,
-  table: Table<JobTableRow>,
-) => {
-  const newValue = typeof updaterOrValue === "function" ? updaterOrValue(currentState) : updaterOrValue
-  if (typeof newValue === "boolean") {
-    const allRowsExpanded = _.fromPairs(table.getRowModel().flatRows.map((r) => [r.id, true]))
-    return allRowsExpanded
-  } else {
-    return newValue
-  }
+export const updaterToValue = <T>(updaterOrValue: Updater<T>, previousValue: T): T => {
+  return typeof updaterOrValue === "function" ? (updaterOrValue as (old: T) => T)(previousValue) : updaterOrValue
 }


### PR DESCRIPTION
- Adds support for selecting/unselecting jobs
- Currently if you select a group (e.g. when grouping by queue and selecting the queue's row) then it will auto select any jobs under that queue
  - This may need to be changed in future if the cancel/reprioritise APIs allow passing of a queue/jobset, rather than just a list of jobs.
- Selected rows are reset on expanded changes and pagination changes
- Adds some basic tests for selection
- Refactors some repeated logic into more useful helpers, e.g. `useStateWithPrevious`
- Fixes a bug where expanded rows would be lost after a hot reload on code change
-  Columns are now manually ordered, to enforce the selected column to be at the start

**Ungrouped**
![image](https://user-images.githubusercontent.com/3807889/204490794-b389bdbe-05da-48d1-942b-f5cc6ef2f5e8.png)

**Grouped**
![image](https://user-images.githubusercontent.com/3807889/204490966-d9039ea6-f810-4b19-b650-a24494215972.png)
