### PR TITLE
Add subrow pagination

### DIFF
--- a/src/components/jobsTable/JobsTable.module.css
+++ b/src/components/jobsTable/JobsTable.module.css
@@ -1,6 +1,9 @@
 
-
-.depthIndicator {
+.rowDepthIndicator {
   background-image: linear-gradient(rgba(224, 224, 224, 1), rgba(224, 224, 224, 1));
   background-repeat: no-repeat;
+}
+
+.loadMoreRow {
+  background-color: rgba(224, 224, 224, 0.35);
 }

--- a/src/components/jobsTable/JobsTable.module.css
+++ b/src/components/jobsTable/JobsTable.module.css
@@ -1,0 +1,6 @@
+
+
+.depthIndicator {
+  background-image: linear-gradient(rgba(224, 224, 224, 1), rgba(224, 224, 224, 1));
+  background-repeat: no-repeat;
+}

--- a/src/components/jobsTable/JobsTable.test.tsx
+++ b/src/components/jobsTable/JobsTable.test.tsx
@@ -21,7 +21,7 @@ describe("JobsTable", () => {
   })
 
   const renderComponent = () =>
-    render(<JobsTable getJobsService={getJobsService} groupJobsService={groupJobsService} />)
+    render(<JobsTable getJobsService={getJobsService} groupJobsService={groupJobsService} debug={false} />)
 
   it("should render a spinner while loading initially", async () => {
     getJobsService.getJobs = jest.fn(() => new Promise(() => undefined))

--- a/src/components/jobsTable/JobsTable.tsx
+++ b/src/components/jobsTable/JobsTable.tsx
@@ -122,8 +122,6 @@ export const JobsTable = ({ getJobsService, groupJobsService, debug }: JobsPageP
       const groupingLevel = grouping.length
       const expandedLevel = rowToLoadSubRowsFor ? rowToLoadSubRowsFor.rowIdPathFromRoot.length : 0
 
-      console.log({ rowsNeedingSubRowsFetched, groupingLevel, expandedLevel })
-
       const skip = !rowToLoadSubRowsFor ? pageIndex * pageSize : subRowToLoadMore ? subRowToLoadMore.skip : 0
 
       const rowRequest = {

--- a/src/components/jobsTable/JobsTable.tsx
+++ b/src/components/jobsTable/JobsTable.tsx
@@ -9,6 +9,7 @@ import {
   CircularProgress,
   TablePagination,
   TableFooter,
+  Button,
 } from "@mui/material"
 import {
   ColumnDef,
@@ -25,13 +26,13 @@ import {
   Updater,
   ExpandedState,
 } from "@tanstack/react-table"
-import { useCallback, useEffect, useMemo, useState } from "react"
+import React, { useCallback, useEffect, useMemo, useState } from "react"
 import GetJobsService from "services/GetJobsService"
 import GroupJobsService from "services/GroupJobsService"
 import { fromRowId, mergeSubRows, RowId } from "utils/reactTableUtils"
 import { JobTableRow, isJobGroupRow } from "models/jobsTableModels"
 import {
-  convertExpandedRowFieldsToFilters,
+  convertRowPartsToFilters,
   fetchJobGroups,
   fetchJobs,
   groupsToRows,
@@ -46,14 +47,17 @@ import { getSelectedColumnDef } from "./SelectedColumn"
 import { useStateWithPrevious } from "hooks/useStateWithPrevious"
 import _ from "lodash"
 import { JobId } from "model"
+import { Box } from "@mui/system"
+import styles from "./JobsTable.module.css";
 
 const DEFAULT_PAGE_SIZE = 30
 
 type JobsPageProps = {
   getJobsService: GetJobsService
   groupJobsService: GroupJobsService
+  debug: boolean
 }
-export const JobsTable = ({ getJobsService, groupJobsService }: JobsPageProps) => {
+export const JobsTable = ({ getJobsService, groupJobsService, debug }: JobsPageProps) => {
   const [isLoading, setIsLoading] = useState(true)
   const [data, setData] = useState<JobTableRow[]>([])
   const [totalRowCount, setTotalRowCount] = useState(0)
@@ -79,10 +83,11 @@ export const JobsTable = ({ getJobsService, groupJobsService }: JobsPageProps) =
 
   const [pagination, setPagination, prevPagination] = useStateWithPrevious<PaginationState>({
     pageIndex: 0,
-    pageSize: DEFAULT_PAGE_SIZE,
+    pageSize: DEFAULT_PAGE_SIZE
   })
   const [pageCount, setPageCount] = useState<number>(-1)
   const { pageIndex, pageSize } = useMemo(() => pagination, [pagination])
+  const [subRowToLoadMore, setSubRowToLoadMore] = useState<{ rowId: RowId, skip: number } | undefined>(undefined)
 
   const [hoveredHeaderColumn, setHoveredHeaderColumn] = useState<ColumnId | undefined>(undefined)
 
@@ -92,31 +97,37 @@ export const JobsTable = ({ getJobsService, groupJobsService }: JobsPageProps) =
       const groupingUnchanged = _.isEqual(grouping, prevGrouping)
       const expandedUnchanged = _.isEqual(expanded, prevExpanded)
       const paginationUnchanged = _.isEqual(pagination, prevPagination)
+      const loadMoreUnchanged = subRowToLoadMore === undefined;
 
       // Relying purely on useEffect's dependencies array doesn't work perfectly (e.g. for hot reloads)
-      if (groupingUnchanged && expandedUnchanged && paginationUnchanged) {
+      if (groupingUnchanged && expandedUnchanged && paginationUnchanged && loadMoreUnchanged) {
         console.log("Not fetching any data as no relevant state has changed")
         return
       }
 
-      if (groupingUnchanged && paginationUnchanged && newlyUnexpanded.length > 0) {
+      if (groupingUnchanged && paginationUnchanged && loadMoreUnchanged && newlyUnexpanded.length > 0) {
         console.log("Not fetching new data since we're only unexpanding")
         return
       }
 
-      if (newlyExpanded.length > 1) {
-        console.warn("More than one newly expanded! This may be a bug.", { newlyExpanded })
+      const rowsNeedingSubRowsFetched = [subRowToLoadMore?.rowId, ...newlyExpanded].filter((r): r is RowId => r !== undefined);
+      if (rowsNeedingSubRowsFetched.length > 1) {
+        console.warn("More than one row needing subrows fetched! This may be a bug.", { newlyExpanded })
       }
 
-      const expandedRowInfo = newlyExpanded.length > 0 ? fromRowId(newlyExpanded[0]) : undefined
+      const rowToLoadSubRowsFor = rowsNeedingSubRowsFetched.length > 0 ? fromRowId(rowsNeedingSubRowsFetched[0]) : undefined
 
       const groupingLevel = grouping.length
-      const expandedLevel = expandedRowInfo ? expandedRowInfo.rowIdPathFromRoot.length : 0
+      const expandedLevel = rowToLoadSubRowsFor ? rowToLoadSubRowsFor.rowIdPathFromRoot.length : 0
+
+      console.log({ rowsNeedingSubRowsFetched, groupingLevel, expandedLevel })
+
+      const skip = !rowToLoadSubRowsFor ? pageIndex * pageSize : (subRowToLoadMore ? subRowToLoadMore.skip : 0);
 
       const rowRequest = {
-        filters: convertExpandedRowFieldsToFilters(expandedRowInfo?.rowIdPartsPath ?? []),
-        skip: expandedRowInfo ? 0 : pageIndex * pageSize,
-        take: expandedRowInfo ? Number.MAX_SAFE_INTEGER : pageSize,
+        filters: convertRowPartsToFilters(rowToLoadSubRowsFor?.rowIdPartsPath ?? []),
+        skip,
+        take: pageSize,
       }
 
       let newData, totalCount
@@ -128,22 +139,36 @@ export const JobsTable = ({ getJobsService, groupJobsService }: JobsPageProps) =
         const groupedCol = grouping[expandedLevel]
         const colsToAggregate = allColumns.filter((c) => c.groupable).map((c) => c.key)
         const { groups, totalGroups } = await fetchJobGroups(rowRequest, groupJobsService, groupedCol, colsToAggregate)
-        newData = groupsToRows(groups, expandedRowInfo?.rowId, groupedCol)
+        newData = groupsToRows(groups, rowToLoadSubRowsFor?.rowId, groupedCol)
         totalCount = totalGroups
       }
 
-      const mergedData = mergeSubRows(data, newData, expandedRowInfo?.rowIdPathFromRoot ?? [])
+      const { rootData, parentRow } = mergeSubRows(data, newData, rowToLoadSubRowsFor?.rowIdPathFromRoot ?? [], !!subRowToLoadMore)
 
-      setData([...mergedData]) // ReactTable will only re-render if the array identity changes
+      if (parentRow) {
+        parentRow.subRowCount = totalCount
+
+        // Update any new children of selected rows
+        if (parentRow.rowId in selectedRows) {
+          const newSelectedRows = (parentRow.subRows ?? []).reduce((newSelectedSubRows, subRow) => {
+            newSelectedSubRows[subRow.rowId] = true;
+            return newSelectedSubRows
+          }, { ...selectedRows });
+          setSelectedRows(newSelectedRows);
+        }
+      }
+
+      setData([...rootData]) // ReactTable will only re-render if the array identity changes
       setIsLoading(false)
-      if (expandedRowInfo === undefined) {
+      setSubRowToLoadMore(undefined)
+      if (rowToLoadSubRowsFor === undefined) {
         setPageCount(Math.ceil(totalCount / pageSize))
         setTotalRowCount(totalCount)
       }
     }
 
     fetchData().catch(console.error)
-  }, [pagination, grouping, expanded])
+  }, [pagination, subRowToLoadMore, grouping, expanded])
 
   const onGroupingChange = useCallback(
     (newState: ColumnId[]) => {
@@ -176,6 +201,10 @@ export const JobsTable = ({ getJobsService, groupJobsService }: JobsPageProps) =
     [pagination, setPagination, setSelectedRows, setExpanded],
   )
 
+  const onLoadMoreSubRows = useCallback((rowId: RowId, skip: number) => {
+    setSubRowToLoadMore({ rowId, skip })
+  }, [setSubRowToLoadMore])
+
   const onExpandedChange = useCallback(
     (updater: Updater<ExpandedState>) => {
       const newExpandedOrBool = updaterToValue(updater, expanded)
@@ -188,6 +217,14 @@ export const JobsTable = ({ getJobsService, groupJobsService }: JobsPageProps) =
     [setExpanded, expanded],
   )
 
+  const onSelectedRowChange = useCallback((updater: Updater<RowSelectionState>) => {
+    const newSelectedRows = updaterToValue(updater, selectedRows)
+    const [addedRowIds, removedRowIds] = diffOfKeys<RowId>(newSelectedRows, selectedRows)
+    console.log({ addedRowIds, removedRowIds });
+
+    setSelectedRows(newSelectedRows)
+  }, [setSelectedRows, selectedRows])
+
   const tableState = useMemo(
     () => ({
       grouping,
@@ -198,6 +235,7 @@ export const JobsTable = ({ getJobsService, groupJobsService }: JobsPageProps) =
     [grouping, expanded, pagination, selectedRows],
   )
 
+  // TODO: Refactor and use Tanstack column pinning?
   const selectedColumnDefs = useMemo<ColumnDef<JobTableRow>[]>(() => {
     const fixedStartColumns = [getSelectedColumnDef()]
     const restOfColumns = [
@@ -231,7 +269,7 @@ export const JobsTable = ({ getJobsService, groupJobsService }: JobsPageProps) =
     enableRowSelection: true,
     enableMultiRowSelection: true,
     enableSubRowSelection: true,
-    onRowSelectionChange: setSelectedRows,
+    onRowSelectionChange: onSelectedRowChange,
 
     // Grouping
     manualGrouping: true,
@@ -251,26 +289,7 @@ export const JobsTable = ({ getJobsService, groupJobsService }: JobsPageProps) =
     getFilteredRowModel: getFilteredRowModel(),
   })
 
-  // Update any new children of selected rows
-  useMemo(() => {
-    const selectedRowIds = Object.keys(selectedRows) as RowId[]
-    selectedRowIds.forEach((rowId) => {
-      try {
-        const row = table.getRow(rowId)
-        if (row.getIsSelected() && !row.getIsSomeSelected()) {
-          row.subRows.forEach((subRow) => {
-            if (!subRow.getIsSelected()) {
-              subRow.toggleSelected(true)
-            }
-          })
-        }
-      } catch (e) {
-        console.warn("Could not update all selected subrows for row: " + rowId, e)
-      }
-    })
-  }, [data])
-
-  const rowsToRender = table.getRowModel().rows
+  const topLevelRows = table.getRowModel().rows.filter(row => row.depth === 0);
   return (
     <>
       <JobsTableActionBar
@@ -297,12 +316,12 @@ export const JobsTable = ({ getJobsService, groupJobsService }: JobsPageProps) =
             ))}
           </TableHead>
 
-          <JobsTableBody dataIsLoading={isLoading} columns={selectedColumnDefs} rowsToRender={rowsToRender} />
+          <JobsTableBody dataIsLoading={isLoading} columns={selectedColumnDefs} topLevelRows={topLevelRows} onLoadMoreSubRows={onLoadMoreSubRows} />
 
           <TableFooter>
             <TableRow>
               <TablePagination
-                rowsPerPageOptions={[10, 20, 30, 40, 50]}
+                rowsPerPageOptions={[3, 10, 20, 30, 40, 50]}
                 count={totalRowCount}
                 rowsPerPage={pageSize}
                 page={pageIndex}
@@ -314,6 +333,8 @@ export const JobsTable = ({ getJobsService, groupJobsService }: JobsPageProps) =
           </TableFooter>
         </Table>
       </TableContainer>
+
+      {debug && <pre>{JSON.stringify(table.getState(), null, 2)}</pre>}
     </>
   )
 }
@@ -321,10 +342,11 @@ export const JobsTable = ({ getJobsService, groupJobsService }: JobsPageProps) =
 interface JobsTableBodyProps {
   dataIsLoading: boolean
   columns: ColumnDef<JobTableRow>[]
-  rowsToRender: Row<JobTableRow>[]
+  topLevelRows: Row<JobTableRow>[]
+  onLoadMoreSubRows: (rowId: RowId, skip: number) => void
 }
-const JobsTableBody = ({ dataIsLoading, columns, rowsToRender }: JobsTableBodyProps) => {
-  const canDisplay = !dataIsLoading && rowsToRender.length > 0
+const JobsTableBody = ({ dataIsLoading, columns, topLevelRows, onLoadMoreSubRows }: JobsTableBodyProps) => {
+  const canDisplay = !dataIsLoading && topLevelRows.length > 0
   return (
     <TableBody>
       {!canDisplay && (
@@ -334,30 +356,51 @@ const JobsTableBody = ({ dataIsLoading, columns, rowsToRender }: JobsTableBodyPr
               <CircularProgress />
             </TableCell>
           )}
-          {!dataIsLoading && rowsToRender.length === 0 && (
+          {!dataIsLoading && topLevelRows.length === 0 && (
             <TableCell colSpan={columns.length}>There is no data to display</TableCell>
           )}
         </TableRow>
       )}
 
-      {rowsToRender.map((row) => {
-        const original = row.original
-        const rowIsGroup = isJobGroupRow(original)
-        return (
-          <TableRow key={`${row.id}_d${row.depth}`} aria-label={row.id} hover>
-            {row.getVisibleCells().map((cell) => (
-              <BodyCell
-                cell={cell}
-                rowIsGroup={rowIsGroup}
-                rowIsExpanded={row.getIsExpanded()}
-                onExpandedChange={row.toggleExpanded}
-                subCount={rowIsGroup ? original.count : undefined}
-                key={cell.id}
-              />
-            ))}
-          </TableRow>
-        )
-      })}
+      {topLevelRows.map(row => recursiveRowRender(row, onLoadMoreSubRows))}
     </TableBody>
+  )
+}
+
+const recursiveRowRender = (row: Row<JobTableRow>, onLoadMoreSubRows: (rowId: RowId, skip: number) => void): JSX.Element => {
+  const original = row.original
+  const rowIsGroup = isJobGroupRow(original)
+  const rowCells = row.getVisibleCells();
+
+  return (
+    <React.Fragment key={`${row.id}_d${row.depth}`}>
+      {/* Render the current row */}
+      <TableRow aria-label={row.id} hover className={styles.depthIndicator} sx={{ backgroundSize: row.depth * 6 }}>
+        {rowCells.map((cell) => (
+          <BodyCell
+            cell={cell}
+            rowIsGroup={rowIsGroup}
+            rowIsExpanded={row.getIsExpanded()}
+            onExpandedChange={row.toggleExpanded}
+            subCount={rowIsGroup ? original.jobCount : undefined}
+            key={cell.id}
+          />
+        ))}
+      </TableRow>
+
+      {/* Render any sub rows if expanded */}
+      {rowIsGroup && row.getIsExpanded() && row.subRows.map(row => recursiveRowRender(row, onLoadMoreSubRows))}
+
+      {/* Render pagination tools for this expanded row */}
+      {rowIsGroup && row.getIsExpanded() && (original.subRowCount ?? 0) > (original.subRows?.length ?? 0) &&
+        <TableRow className={styles.depthIndicator} sx={{ backgroundSize: (row.depth + 1) * 6, backgroundColor: "rgba(224, 224, 224, 0.35)" }}>
+          <TableCell colSpan={row.getVisibleCells().length} align="center" size="small">
+            <Button size="small" variant="text" onClick={() => onLoadMoreSubRows(row.id as RowId, original.subRows?.length ?? 0)}>
+              Load more
+            </Button>
+          </TableCell>
+        </TableRow>
+      }
+    </React.Fragment>
   )
 }

--- a/src/models/jobsTableModels.ts
+++ b/src/models/jobsTableModels.ts
@@ -17,7 +17,9 @@ export interface JobRow extends BaseJobTableRow {
 
 export interface JobGroupRow extends BaseJobTableRow {
   isGroup: true // The ReactTable version of this doesn't seem to play nice with manual/serverside expanding
-  count?: number
+  jobCount?: number
+
+  subRowCount?: number
   subRows?: JobTableRow[]
 
   // Some subfield of JobRow that this row is grouped on
@@ -26,4 +28,4 @@ export interface JobGroupRow extends BaseJobTableRow {
 
 export type JobTableRow = JobRow | JobGroupRow
 
-export const isJobGroupRow = (row: JobTableRow): row is JobGroupRow => "isGroup" in row
+export const isJobGroupRow = (row?: JobTableRow): row is JobGroupRow => row !== undefined && "isGroup" in row

--- a/src/models/jobsTableModels.ts
+++ b/src/models/jobsTableModels.ts
@@ -20,10 +20,11 @@ export interface JobGroupRow extends BaseJobTableRow {
   jobCount?: number
 
   subRowCount?: number
-  subRows?: JobTableRow[]
+  subRows: JobTableRow[]
 
   // Some subfield of JobRow that this row is grouped on
   [groupedField: string]: unknown
+  groupedField: string
 }
 
 export type JobTableRow = JobRow | JobGroupRow

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -46,6 +46,9 @@ const theme = createTheme({
 const NAVBAR_HEIGHT = 64
 
 function App() {
+  const queryParams = new URLSearchParams(window.location.search)
+  const isDebugEnabled = queryParams.has("debug")
+
   const [dims, setDims] = useState({ width: 0, height: 0 })
 
   const ref = useRef<HTMLDivElement>(null)
@@ -84,6 +87,7 @@ function App() {
                   width={dims.width}
                   getJobsService={new FakeGetJobsService(testJobs)}
                   groupJobsService={new FakeGroupJobsService(testJobs)}
+                  debug={isDebugEnabled}
                 />
               }
             />

--- a/src/pages/JobsPage.tsx
+++ b/src/pages/JobsPage.tsx
@@ -8,12 +8,13 @@ type JobsPageProps = {
   height: number
   getJobsService: GetJobsService
   groupJobsService: GroupJobsService
+  debug: boolean
 }
 
 export default function JobsPage(props: JobsPageProps) {
   return (
     <div className={styles.jobsTable}>
-      <JobsTable getJobsService={props.getJobsService} groupJobsService={props.groupJobsService} />
+      <JobsTable getJobsService={props.getJobsService} groupJobsService={props.groupJobsService} debug={props.debug} />
     </div>
   )
 }

--- a/src/utils/jobsTableUtils.test.ts
+++ b/src/utils/jobsTableUtils.test.ts
@@ -1,14 +1,14 @@
-import { convertExpandedRowFieldsToFilters, diffOfKeys } from "./jobsTableUtils"
+import { convertRowPartsToFilters, diffOfKeys } from "./jobsTableUtils"
 
 describe("JobsTableUtils", () => {
   describe("convertExpandedRowFieldsToFilters", () => {
     it("returns empty if not expanding a row", () => {
-      const result = convertExpandedRowFieldsToFilters([])
+      const result = convertRowPartsToFilters([])
       expect(result).toStrictEqual([])
     })
 
     it("returns one filter when expanding a top level row", () => {
-      const result = convertExpandedRowFieldsToFilters([{ type: "queue", value: "queue-2" }])
+      const result = convertRowPartsToFilters([{ type: "queue", value: "queue-2" }])
       expect(result).toStrictEqual([
         {
           field: "queue",
@@ -19,7 +19,7 @@ describe("JobsTableUtils", () => {
     })
 
     it("returns multiple filters when expanding a nested row", () => {
-      const result = convertExpandedRowFieldsToFilters([
+      const result = convertRowPartsToFilters([
         { type: "jobSet", value: "job-set-2" },
         {
           type: "queue",

--- a/src/utils/jobsTableUtils.test.ts
+++ b/src/utils/jobsTableUtils.test.ts
@@ -1,7 +1,7 @@
 import { convertRowPartsToFilters, diffOfKeys } from "./jobsTableUtils"
 
 describe("JobsTableUtils", () => {
-  describe("convertExpandedRowFieldsToFilters", () => {
+  describe("convertRowPartsToFilters", () => {
     it("returns empty if not expanding a row", () => {
       const result = convertRowPartsToFilters([])
       expect(result).toStrictEqual([])

--- a/src/utils/jobsTableUtils.ts
+++ b/src/utils/jobsTableUtils.ts
@@ -6,7 +6,7 @@ import GetJobsService from "services/GetJobsService"
 import GroupJobsService from "services/GroupJobsService"
 import { RowIdParts, toRowId, RowId } from "./reactTableUtils"
 
-export const convertExpandedRowFieldsToFilters = (expandedRowIdParts: RowIdParts[]): JobFilter[] => {
+export const convertRowPartsToFilters = (expandedRowIdParts: RowIdParts[]): JobFilter[] => {
   const filters: JobFilter[] = expandedRowIdParts.map(({ type, value }) => ({
     field: type,
     value,
@@ -64,10 +64,14 @@ export const groupsToRows = (
     (group): JobGroupRow => ({
       rowId: toRowId({ type: groupingField, value: group.name, parentRowId: baseRowId }),
       [groupingField]: group.name,
+      groupedField: groupingField,
 
       isGroup: true,
-      count: group.count,
-      subRows: [], // Will be set later if expanded
+      jobCount: group.count,
+
+      // Will be set later if expanded
+      subRowCount: undefined,
+      subRows: [],
     }),
   )
 }

--- a/src/utils/reactTableUtils.test.ts
+++ b/src/utils/reactTableUtils.test.ts
@@ -82,7 +82,7 @@ describe("ReactTableUtils", () => {
       existingData = [{ rowId: "fruit:apple" }]
       newRows = [{ rowId: "fruit:banana" }]
       locationForSubRows = []
-      const result = mergeSubRows(existingData, newRows, locationForSubRows)
+      const result = mergeSubRows(existingData, newRows, locationForSubRows, false)
       expect(result).toStrictEqual(newRows)
     })
 
@@ -94,7 +94,7 @@ describe("ReactTableUtils", () => {
       newRows = [{ rowId: "taste:delicious" }]
       locationForSubRows = ["fruit:banana"]
 
-      const result = mergeSubRows(existingData, newRows, locationForSubRows)
+      const result = mergeSubRows(existingData, newRows, locationForSubRows, false)
 
       expect(result).toStrictEqual([
         { rowId: "fruit:apple", subRows: [] },
@@ -110,7 +110,7 @@ describe("ReactTableUtils", () => {
       newRows = [{ rowId: "taste:delicious" }]
       locationForSubRows = ["fruit:avocado"]
 
-      const result = mergeSubRows(existingData, newRows, locationForSubRows)
+      const result = mergeSubRows(existingData, newRows, locationForSubRows, false)
 
       expect(result).toStrictEqual(existingData)
     })

--- a/src/utils/reactTableUtils.ts
+++ b/src/utils/reactTableUtils.ts
@@ -94,12 +94,12 @@ export const mergeSubRows = <
   const rowToModify = locationForSubRows.reduce<TGroupedRow | undefined>(
     (row, rowIdToFind) => {
       if (isGroupedRow(row)) {
+        // TODO: Change subRows to a set to optimise this lookup
         const candidateRow = row.subRows.find((r) => r.rowId === rowIdToFind)
         if (isGroupedRow(candidateRow)) {
           return candidateRow
         }
       }
-      // TODO: Change subRows to a set to optimise this lookup
     },
     { subRows: existingData } as TGroupedRow,
   )


### PR DESCRIPTION
- Only loads the current-page-size worth of data for subgroups
- Adds a "Load more" button if there's more data available for a subgroup
  - If the parent row is selected, and then any newly added rows will be automatically selected
- Adds a subtle "depth gauge" for subrows on the left side of the row
- Adds a `debug` flag to print out the full Tanstack table state

**Page size = 3**
![image](https://user-images.githubusercontent.com/3807889/204833013-217b9558-b1e5-4ec7-8808-8b3943276bee.png)

**Multiple different levels of groups, with multiple layers of pagination** Note: This shouldn't be a very common scenario if page sizes are reasonable (~100)
![image](https://user-images.githubusercontent.com/3807889/204833236-f718d665-d6d7-4330-a782-d2ed2376c18f.png)

**Debug flag enabled in URL**
![image](https://user-images.githubusercontent.com/3807889/204833656-90c74dca-736a-4583-9569-d567e07554d8.png)

